### PR TITLE
Compiler: 带索引的表达式写的的差不多了

### DIFF
--- a/src/frontend/compiler/.gitignore
+++ b/src/frontend/compiler/.gitignore
@@ -23,3 +23,5 @@ cabal.project.local~
 .ghc.environment.*
 stack.yaml.lock
 *.cabal
+
+hie.yaml

--- a/src/frontend/compiler/package.yaml
+++ b/src/frontend/compiler/package.yaml
@@ -7,6 +7,7 @@ ghc-options:
 dependencies:
   - base >= 4.7 && < 5
   - mtl == 2.2.2
+  - containers == 0.6.2.1
 
 library:
   source-dirs:

--- a/src/frontend/compiler/src/CodeGenerator/CodeGenerator.hs
+++ b/src/frontend/compiler/src/CodeGenerator/CodeGenerator.hs
@@ -1,3 +1,156 @@
 {-# LANGUAGE LambdaCase #-}
 
 module CodeGenerator where
+
+
+import Ast
+import Expr
+import Instruction
+import FFIStructure
+import CodeGeneratorUtils
+
+import Data.Maybe
+import qualified Data.Map as Map
+
+
+cExprWrapper :: Expr -> CodeGenEnv
+cExprWrapper expr = getMetadata >>= \mds -> uncurry (wrapperExpr mds) (splitExpr expr mds) where
+    wrapperExpr :: [TableMetadata] ->  [(Int, String, [Expr])] -> [Expr] -> CodeGenEnv
+    wrapperExpr mds inp condExpr = openTbAndIdx >> wrapper >> closeTbAndIdx where
+        wrapper = getLabel >>= \lab
+                -> updateLabel
+                >> wrapper' tbNames idxNames (map trd3 inp) lab
+                >> mkLabel lab
+
+        openTbAndIdx  = connectCodeGenEnv
+            $ zipWith (\a b -> appendInst opOpen a 0 b) [0..]
+            $ allTbNames ++ idxNames
+
+        closeTbAndIdx = connectCodeGenEnv
+            $ map (\i -> appendInst opClose i 0 "") [0..(length allTbNames + length inp - 1)]
+
+        wrapper' (tb:tbs) (idx:idxes) (key:keys) labEnd =
+            let mkKey = connectCodeGenEnv (map cExpr key)
+                    >> appendInst opMakeKey (length key) 0 ""
+                    >> appendInst opBeginIdx (getIdxCursor idx) 0 ""
+                mvCursor = appendInst opNextIdx (getIdxCursor idx) labEnd ""
+                    >> appendInst opMoveTo (getTbCursor tb) 0 ""
+             in getLabel >>= \lab -> updateLabel
+                                  >> mkKey
+                                  >> mkLabel lab
+                                  >> mvCursor
+                                  >> wrapper' tbs idxes keys lab
+
+        wrapper' _ _ _ labEnd =
+            let rewind  = map (\tbName -> appendInst opRewind (getTbCursor tbName) 0      ""
+                                       >> appendInst opNext   (getTbCursor tbName) labEnd "") tbNotUseIdx
+             in case rewind of
+                 [] -> connectCodeGenEnv (condExpr' labEnd)
+                    >> appendInst opTempInst 0 0 ""
+                    >> appendInst opGoto 0 labEnd ""
+                 _  -> getLabel >>= \lab
+                    -> updateLabel
+                    >> connectCodeGenEnv rewind
+                    >> mkLabel lab
+                    >> connectCodeGenEnv (condExpr' lab)
+                    >> appendInst opTempInst 0 0 ""
+                    >> appendInst opGoto 0 lab ""
+            where
+                condExpr' lab = case condExpr of
+                    [] -> []
+                    _  -> [cExpr $ foldl1 (BinExpr And) condExpr
+                          ,appendInst opNot 0 0 ""
+                          ,appendInst opJIf 0 lab ""]
+                tbNotUseIdx  = filter (`notElem` tbNames) allTbNames
+
+        -- some help functions
+        idxNames = map snd3 inp
+        tbNames  = map (\i -> metadata_name $ mds !! fst3 i) inp
+        allTbNames  = map metadata_name mds
+
+        getTbCursor  tbName  = snd . head $ dropWhile ((/=tbName)  . fst) tbNameCursor where
+            tbNameCursor = zip allTbNames [0..]
+
+        getIdxCursor idxName = snd . head $ dropWhile ((/=idxName) . fst) idxCursor where
+            idxCursor    = zip idxNames [(length allTbNames) ..]
+
+    splitExpr :: Expr -> [TableMetadata] -> ([(Int, String, [Expr])], [Expr])
+    splitExpr e mds =
+        let (eqPair, othExpr) = collectExpr e
+            (key, combinedExpr) = splitEqPairToMkKey eqPair mds
+         in (key, combinedExpr ++ othExpr)
+
+    collectExpr :: Expr -> ([(Expr, Expr)], [Expr])
+    collectExpr expr' = collectExpr' expr' [] [] where
+        collectExpr' e@(BinExpr Eq e1 e2) a b =
+            case (e1, e2) of
+                (e1'@(Column _)       , e2') | isConstExpr e2' -> ((e1', e2') : a, b)
+                (e1'@(TableColumn _ _), e2') | isConstExpr e2' -> ((e1', e2') : a, b)
+                (e1', e2'@(Column _))        | isConstExpr e1' -> ((e2', e1') : a, b)
+                (e1', e2'@(TableColumn _ _)) | isConstExpr e1' -> ((e2', e1') : a, b)
+                _ -> (a, e : b)
+        collectExpr' (BinExpr And e1 e2) a b =
+            let (e1a, e1b) = collectExpr' e1 a b
+             in collectExpr' e2 e1a e1b
+        collectExpr' e a b = (a, e : b)
+
+    groupEqPairByTable :: [(Expr, Expr)] -> [TableMetadata] -> Maybe [(Int, [(Expr, Expr)])]
+    groupEqPairByTable eqPair mds = groupEqPairByTable' eqPair $ Map.fromList [] where
+        groupEqPairByTable' [] m = Just $ Map.toList m
+        groupEqPairByTable' (p:ps) m = case p of
+            (TableColumn tn cn, _) -> case tableColumnIdx tn cn mds of
+                (-1, _) -> Nothing
+                (i , _) -> groupEqPairByTable' ps $ updateMap i p m
+            (Column cn, x) -> case columnIdx cn mds of
+                (-1, _) -> Nothing
+                (i , _) -> groupEqPairByTable' ps
+                         $ updateMap i (TableColumn (metadata_name $ mds !! i) cn, x) m
+            _ -> Nothing
+            where
+                updateMap tbIdx pair m' =
+                    let oldVal = fromMaybe [] $ Map.lookup tbIdx m'
+                     in Map.insert tbIdx (pair:oldVal) m'
+
+    findBestIndexInColumnList :: [TableIndex] -> [Expr] -> Maybe TableIndex
+    findBestIndexInColumnList tbIdxes cols =
+        let allProb = findAllProbIndex tbIdxes []
+         in findBestIndex allProb 0 Nothing
+        where
+            colNames = map (\(TableColumn _ cn) -> cn) cols
+
+            findAllProbIndex [] res = res
+            findAllProbIndex (i:is) res =
+                if   all (`elem` colNames) $ snd i
+                then findAllProbIndex is $ i : res
+                else findAllProbIndex is res
+
+            findBestIndex [] _ res = res
+            findBestIndex (i:is) len res =
+                let len' = length $ snd i
+                 in if   len' > len
+                    then findBestIndex is len' $ Just i
+                    else findBestIndex is len res
+
+    splitEqPairToMkKey :: [(Expr, Expr)] -> [TableMetadata] -> ([(Int, String, [Expr])], [Expr])
+    splitEqPairToMkKey pairs mds =
+        let groupedPair  = fromMaybe [] $ groupEqPairByTable pairs mds
+            idxToUse     = map (\(a, b) -> findBestIndexInColumnList (getTbIdx a) $ map fst b) groupedPair
+            (key, cmbd)  = unzip $ zipWith reSplitPair idxToUse groupedPair
+            indexKey     = map (\(Just x) -> x)
+                         $ filter (\case {Nothing -> False; _ -> True}) key
+         in (indexKey, concat cmbd)
+        where
+            getTbIdx i = metadata_index $ mds !! i
+
+            connEqPair = uncurry $ BinExpr Eq
+
+            -- split eq-pair to (maybe (tbIndex, idxName, key), combined-eq-pair)
+            reSplitPair :: Maybe TableIndex -> (Int, [(Expr, Expr)]) -> (Maybe (Int, String, [Expr]), [Expr])
+            reSplitPair Nothing x = (Nothing, map connEqPair $ snd x)
+            reSplitPair (Just (idxName, cns)) ps =
+                let ps' = filter inIndex $ snd ps
+                    key = map (\cn -> snd . head $ dropWhile (\(TableColumn _ cn', _) -> cn' /= cn) ps') cns
+                 in (Just (fst ps, idxName, key), map connEqPair $ filter (not . inIndex) $ snd ps)
+                where
+                    inIndex (TableColumn _ cn, _) = cn `elem` cns
+                    inIndex _ = False

--- a/src/frontend/compiler/src/CodeGenerator/CodeGeneratorUtils.hs
+++ b/src/frontend/compiler/src/CodeGenerator/CodeGeneratorUtils.hs
@@ -13,7 +13,7 @@ import Control.Monad.Except
 ----------------------------------------------------------
 -- some data structure
 ----------------------------------------------------------
-type CodeGenCnt   = (Int, Int, Int) -- (label-cnt, set-cnt, cursor-cnt)
+type CodeGenCnt   = (Int, Int) -- (label-cnt, set-cnt)
 
 type FunctionDef  = (String, Int, Maybe OpCode)
 
@@ -41,10 +41,10 @@ clrRes = putRes []
 
 -- functions to operate label
 getLabel :: ExceptTEnv Int
-getLabel = fst3 . trd3 <$> lift get
+getLabel = fst . trd3 <$> lift get
 
 putLabel :: Int -> CodeGenEnv
-putLabel l = get >>= (\(a, b, (_, d, e)) -> put (a, b, (l, d, e))) >> getRes
+putLabel l = get >>= (\(a, b, (_, d)) -> put (a, b, (l, d))) >> getRes
 
 updateLabel :: CodeGenEnv
 updateLabel = getLabel >>= (\x -> putLabel $ x + 1)
@@ -58,24 +58,13 @@ mkCurrentLabel = getLabel >>= mkLabel >> updateLabel
 
 -- functions to operate set
 getSet :: ExceptTEnv Int
-getSet = snd3 . trd3 <$> lift get
+getSet = snd . trd3 <$> lift get
 
 putSet :: Int -> CodeGenEnv
-putSet s = get >>= (\(a, b, (c, _, e)) -> put (a, b, (c, s, e))) >> getRes
+putSet s = get >>= (\(a, b, (c, _)) -> put (a, b, (c, s))) >> getRes
 
 updateSet :: CodeGenEnv
 updateSet = getSet >>= \x -> putSet $ x + 1
-
-
--- functions to operate cursor
-getCursor :: ExceptTEnv Int
-getCursor = trd3 . trd3 <$> lift get
-
-putCursor :: Int -> CodeGenEnv
-putCursor x = get >>= (\(a, b, (c, d, _)) -> put (a, b, (c, d, x))) >> getRes
-
-updateCursor :: CodeGenEnv
-updateCursor = getCursor >>= \x -> putCursor $ x + 1
 
 
 -- append an instruction to env

--- a/src/frontend/compiler/src/CodeGenerator/CodeGeneratorUtils.hs
+++ b/src/frontend/compiler/src/CodeGenerator/CodeGeneratorUtils.hs
@@ -71,8 +71,8 @@ updateCursor = getCursor >>= \x -> putCursor $ x + 1
 
 
 -- append an instruction to env
-appendInst :: Instruction -> CodeGenEnv
-appendInst inst = get >>= (\(a, b, c) -> put (a, b ++ [inst], c)) >> getRes
+appendInst :: OpCode -> Int -> Int -> String -> CodeGenEnv
+appendInst opCode p1 p2 p3 = get >>= (\(a, b, c) -> put (a, b ++ [Instruction opCode p1 p2 p3], c)) >> getRes
 
 -- fst, snd, trd for (,,)
 fst3 :: (a, b, c) -> a

--- a/src/frontend/compiler/src/CodeGenerator/CodeGeneratorUtils.hs
+++ b/src/frontend/compiler/src/CodeGenerator/CodeGeneratorUtils.hs
@@ -11,9 +11,11 @@ import Control.Monad.Except
 ----------------------------------------------------------
 -- some data structure
 ----------------------------------------------------------
-type CodeGenCnt   = (Int, Int) -- (label-cnt, set-cnt)
+type CodeGenCnt   = (Int, Int, Int) -- (label-cnt, set-cnt, cursor-cnt)
 
-type CodeGenState = ([TableMetadata], [Instruction], CodeGenCnt)
+type FunctionDef  = (String, Int, Maybe OpCode)
+
+type CodeGenState = (([TableMetadata], [FunctionDef]), [Instruction], CodeGenCnt)
 
 type ExceptTEnv a = ExceptT String (State CodeGenState) a
 
@@ -37,10 +39,10 @@ clrRes = putRes []
 
 -- functions to operate label
 getLabel :: ExceptTEnv Int
-getLabel = fst . trd3 <$> lift get
+getLabel = fst3 . trd3 <$> lift get
 
 putLabel :: Int -> CodeGenEnv
-putLabel l = get >>= (\(a, b, (_, d)) -> put (a, b, (l, d))) >> getRes
+putLabel l = get >>= (\(a, b, (_, d, e)) -> put (a, b, (l, d, e))) >> getRes
 
 updateLabel :: CodeGenEnv
 updateLabel = getLabel >>= (\x -> putLabel $ x + 1)
@@ -48,13 +50,25 @@ updateLabel = getLabel >>= (\x -> putLabel $ x + 1)
 
 -- functions to operate set
 getSet :: ExceptTEnv Int
-getSet = snd . trd3 <$> lift get
+getSet = snd3 . trd3 <$> lift get
 
 putSet :: Int -> CodeGenEnv
-putSet s = get >>= (\(a, b, (c, _)) -> put (a, b, (c, s))) >> getRes
+putSet s = get >>= (\(a, b, (c, _, e)) -> put (a, b, (c, s, e))) >> getRes
 
 updateSet :: CodeGenEnv
 updateSet = getSet >>= \x -> putSet $ x + 1
+
+
+-- functions to operate cursor
+getCursor :: ExceptTEnv Int
+getCursor = trd3 . trd3 <$> lift get
+
+putCursor :: Int -> CodeGenEnv
+putCursor x = get >>= (\(a, b, (c, d, _)) -> put (a, b, (c, d, x))) >> getRes
+
+updateCursor :: CodeGenEnv
+updateCursor = getCursor >>= \x -> putCursor $ x + 1
+
 
 -- append an instruction to env
 appendInst :: Instruction -> CodeGenEnv
@@ -71,5 +85,8 @@ trd3 :: (a, b, c) -> c
 trd3 (_, _, a) = a
 
 -- get table metadata from env
-getMetadata :: ExceptT String (State CodeGenState) [TableMetadata]
-getMetadata = fst3 <$> lift get
+getMetadata :: ExceptTEnv [TableMetadata]
+getMetadata = fst . fst3 <$> lift get
+
+getFuncDef :: ExceptTEnv [FunctionDef]
+getFuncDef = snd . fst3 <$> lift get

--- a/src/frontend/compiler/src/CodeGenerator/Expr.hs
+++ b/src/frontend/compiler/src/CodeGenerator/Expr.hs
@@ -125,10 +125,11 @@ exprCompr op e1 e2 = cExpr e1 >> cExpr e2 >> cComprOp op
 
 -- code generator for and-expr
 exprAnd :: Expr -> Expr -> CodeGenEnv
-exprAnd e1 e2 = getLabel >>= \labelAva
-    -> updateLabel
-    >> cExpr e1 >> gotoWhenFalse labelAva
-    >> cExpr e2 >> gotoWhenFalse labelAva
+exprAnd e1 e2 = getLabel >>= \labelAva -> updateLabel
+    >> cExpr e1
+    >> appendInst opJIf 1 labelAva ""
+    >> cExpr e2
+    >> appendInst opJIf 1 labelAva ""
     >> putTrue  >> getLabel >>= goto
     >> mkLabel labelAva
     >> putFalse
@@ -137,10 +138,11 @@ exprAnd e1 e2 = getLabel >>= \labelAva
 
 -- code generator for or-expr
 exprOr :: Expr -> Expr -> CodeGenEnv
-exprOr e1 e2 = getLabel >>= \labelAva
-    -> updateLabel
-    >> cExpr e1 >> gotoWhenTrue labelAva
-    >> cExpr e2 >> gotoWhenTrue labelAva
+exprOr e1 e2 = getLabel >>= \labelAva -> updateLabel
+    >> cExpr e1
+    >> appendInst opJIf 0 labelAva ""
+    >> cExpr e2
+    >> appendInst opJIf 0 labelAva ""
     >> putFalse >> getLabel >>= goto
     >> mkLabel labelAva
     >> putTrue
@@ -180,12 +182,6 @@ cComprOp op =
 -- make goto instruction
 goto :: Int -> CodeGenEnv
 goto label = appendInst opGoto 0 label ""
-
-gotoWhenTrue :: Int -> CodeGenEnv
-gotoWhenTrue label = appendInst opJIf 0 label ""
-
-gotoWhenFalse :: Int -> CodeGenEnv
-gotoWhenFalse label = appendInst opNot  0 0 "" >> gotoWhenTrue label
 
 dup :: CodeGenEnv
 dup = appendInst opDup 0 0 ""

--- a/src/frontend/compiler/src/CodeGenerator/Expr.hs
+++ b/src/frontend/compiler/src/CodeGenerator/Expr.hs
@@ -1,17 +1,13 @@
 {-# LANGUAGE LambdaCase #-}
-module Expr (cExpr, cExprWrapper) where
+module Expr (cExpr, isConstExpr) where
 
 
 import Ast
 import Instruction
-import FFIStructure
 import CodeGeneratorUtils
 
-import Data.List
-import Data.Maybe
 import Control.Monad.Except
 
-import qualified Data.Map as Map
 
 ----------------------------------------------------------
 -- Code Generator
@@ -19,8 +15,8 @@ import qualified Data.Map as Map
 cExpr :: Expr -> CodeGenEnv
 cExpr = \case
     BinExpr op e1 e2
-        | op == And                                 -> exprAnd e1 e2
-        | op == Or                                  -> exprOr  e1 e2
+        | op == And                                 -> exprAnd e2 e1
+        | op == Or                                  -> exprOr  e2 e1
         | op `elem` [Plus, Minus, Divide, Multiply] -> exprArith op e1 e2
         | otherwise                                 -> exprCompr op e1 e2
     LikeExpr op e1 e2                               -> exprLike  op e1 e2
@@ -36,95 +32,6 @@ cExpr = \case
     _                                               -> throwError "Semantic error"
 
 
-cExprWrapper :: Expr -> CodeGenEnv
-cExprWrapper expr =
-    let 
-     in splitExpr expr <$> getMetadata >>= cMakeKey . fst
-    where
-        cMakeKey :: [(String, [Expr])] -> CodeGenEnv
-        cMakeKey inp = getCursor >>= \cursorN
-                    -> foldl1 (>>) $ zipWith (\a b -> appendInst opOpen a 0 b) [cursorN ..] (map fst inp) 
-
-        splitExpr e mds =
-            let (eqPair, othExpr) = collectExpr e
-                (key, combinedExpr) = splitEqPairToMkKey eqPair mds
-             in (key, combinedExpr ++ othExpr)
-
-        collectExpr expr' = collectExpr' expr' [] [] where
-            collectExpr' e@(BinExpr Eq e1 e2) a b =
-                case (e1, e2) of
-                    (e1'@(Column _)       , e2') | isConstExpr e2' -> ((e1', e2') : a, b)
-                    (e1'@(TableColumn _ _), e2') | isConstExpr e2' -> ((e1', e2') : a, b)
-                    (e1', e2'@(Column _))        | isConstExpr e1' -> ((e2', e1') : a, b)
-                    (e1', e2'@(TableColumn _ _)) | isConstExpr e1' -> ((e2', e1') : a, b)
-                    _ -> (a, e : b)
-            collectExpr' (BinExpr And e1 e2) a b =
-                let (e1a, e1b) = collectExpr' e1 a b
-                in collectExpr' e2 e1a e1b
-            collectExpr' e a b = (a, e : b)
-
-        groupEqPairByTable :: [(Expr, Expr)] -> [TableMetadata] -> Maybe [(Int, [(Expr, Expr)])]
-        groupEqPairByTable eqPair mds = groupEqPairByTable' eqPair $ Map.fromList [] where
-            groupEqPairByTable' [] m = Just $ Map.toList m
-            groupEqPairByTable' (p:ps) m = case p of
-                (TableColumn tn cn, _) -> case tableColumnIdx tn cn mds of
-                    (-1, _) -> Nothing
-                    (i , _) -> groupEqPairByTable' ps $ updateMap i p m
-                (Column cn, x) -> case columnIdx cn mds of
-                    (-1, _) -> Nothing
-                    (i , _) -> groupEqPairByTable' ps
-                             $ updateMap i (TableColumn (metadata_name $ mds !! i) cn, x) m
-                _ -> Nothing
-                where
-                    updateMap tbIdx pair m' =
-                        let oldVal = fromMaybe [] $ Map.lookup tbIdx m'
-                         in Map.insert tbIdx (pair:oldVal) m'
-
-        findBestIndexInColumnList :: [TableIndex] -> [Expr] -> Maybe TableIndex
-        findBestIndexInColumnList tbIdxes cols =
-            let allProb = findAllProbIndex tbIdxes []
-             in findBestIndex allProb 0 Nothing
-            where
-                colNames = map (\(TableColumn _ cn) -> cn) cols
-
-                findAllProbIndex [] res = res
-                findAllProbIndex (i:is) res =
-                    if all (`elem` colNames) $ snd i
-                    then findAllProbIndex is $ i : res
-                    else findAllProbIndex is res
-
-                findBestIndex [] _ res = res
-                findBestIndex (i:is) len res =
-                    let len' = length $ snd i
-                    in if   len' > len
-                       then findBestIndex is len' $ Just i
-                       else findBestIndex is len res
-
-        splitEqPairToMkKey :: [(Expr, Expr)] -> [TableMetadata] -> ([(String, [Expr])], [Expr])
-        splitEqPairToMkKey pairs mds =
-            let groupedPair  = fromMaybe [] $ groupEqPairByTable pairs mds
-                idxToUse     = map (\(a, b) -> findBestIndexInColumnList (getTbIdx a) $ map fst b) groupedPair
-                (key, cmbd)  = unzip $ zipWith reSplitPair idxToUse $ map snd groupedPair
-                indexKey     = map (\(Just x) -> x)
-                             $ filter (\case {Nothing -> False; _ -> True}) key
-             in (indexKey, concat cmbd)
-            where
-                getTbIdx i = metadata_index $ mds !! i
-
-                connEqPair = uncurry $ BinExpr Eq
-
-                -- split eq-pair to (maybe (idxName, key), combined-eq-pair)
-                reSplitPair :: Maybe TableIndex -> [(Expr, Expr)] -> (Maybe (String, [Expr]), [Expr])
-                reSplitPair Nothing x = (Nothing, map connEqPair x)
-                reSplitPair (Just (idxName, cns)) ps =
-                    let ps' = filter inIndex ps
-                        key = map (\cn -> snd . head $ dropWhile (\(TableColumn _ cn', _) -> cn' /= cn) ps') cns
-                     in (Just (idxName, key), map connEqPair $ filter (not . inIndex) ps)
-                    where
-                        inIndex (TableColumn _ cn, _) = cn `elem` cns
-                        inIndex _ = False
-
-
 -- code generator for between-expr
 exprBetween :: Expr -> Expr -> Expr -> CodeGenEnv
 exprBetween a b c = getLabel >>= \labelAva
@@ -135,7 +42,7 @@ exprBetween a b c = getLabel >>= \labelAva
     >> cExpr b >> appendInst opJLt 0 labelAva ""   -- stack: a,a,b -> a
     >> pop 1 >> putTrue
     >> getLabel >>= goto
-    >> mkLabel' labelAva
+    >> mkLabel labelAva
     >> pop 1 >> putFalse
     >> mkCurrentLabel
 
@@ -223,7 +130,7 @@ exprAnd e1 e2 = getLabel >>= \labelAva
     >> cExpr e1 >> gotoWhenFalse labelAva
     >> cExpr e2 >> gotoWhenFalse labelAva
     >> putTrue  >> getLabel >>= goto
-    >> mkLabel' labelAva
+    >> mkLabel labelAva
     >> putFalse
     >> mkCurrentLabel
 
@@ -235,7 +142,7 @@ exprOr e1 e2 = getLabel >>= \labelAva
     >> cExpr e1 >> gotoWhenTrue labelAva
     >> cExpr e2 >> gotoWhenTrue labelAva
     >> putFalse >> getLabel >>= goto
-    >> mkLabel' labelAva
+    >> mkLabel labelAva
     >> putTrue
     >> mkCurrentLabel
 
@@ -280,18 +187,6 @@ gotoWhenTrue label = appendInst opJIf 0 label ""
 gotoWhenFalse :: Int -> CodeGenEnv
 gotoWhenFalse label = appendInst opNot  0 0 "" >> gotoWhenTrue label
 
-
--- make label without update
-mkLabel' :: Int -> CodeGenEnv
-mkLabel' label = appendInst opNoop 0 label ""
-
--- make label and update label number
-mkLabel :: Int -> CodeGenEnv
-mkLabel label  = mkLabel' label >> updateLabel
-
-mkCurrentLabel :: CodeGenEnv
-mkCurrentLabel = getLabel >>= mkLabel
-
 dup :: CodeGenEnv
 dup = appendInst opDup 0 0 ""
 
@@ -305,7 +200,6 @@ putTrue = appendInst opInteger 1 0 ""
 putFalse :: CodeGenEnv
 putFalse = appendInst opInteger 0 0 ""
 
-
 mkBoolVal :: OpCode -> Int -> Int -> String -> CodeGenEnv
 mkBoolVal opCode p1 p2 p3 = appendInst opCode p1 p2 p3
     >> putFalse
@@ -313,7 +207,6 @@ mkBoolVal opCode p1 p2 p3 = appendInst opCode p1 p2 p3
     >> mkCurrentLabel
     >> putTrue
     >> mkCurrentLabel
-
 
 -- const expr checker
 isConstExpr :: Expr -> Bool
@@ -333,23 +226,3 @@ throwErrorIfNotConst :: Expr -> CodeGenEnv
 throwErrorIfNotConst expr
     | isConstExpr expr = return []
     | otherwise        = throwError "Right-hand side of IN operator must be constant"
-
-
--- get column index from metadatas, return: (table-index, column-index)
-columnIdx :: String -> [TableMetadata] -> (Int, Int)
-columnIdx cn mds =
-    let valid     md = cn `elem` metadata_column md
-        getColIdx md = fromMaybe (-1) $ elemIndex cn $ metadata_column md
-     in case findIndices valid mds of
-            [i] -> (i, getColIdx $ mds !! i)
-            []  -> (-1, -1)  -- can not found
-            _   -> (-1,  0)  -- can find column but can not determine which table to use
-
-
--- get table-column index from metadatas, return: (table-index, column-index)
-tableColumnIdx :: String -> String -> [TableMetadata] -> (Int, Int)
-tableColumnIdx tn cn mds = case findIndex ((==tn) . metadata_name) mds of
-    Nothing -> (-1, 0)     -- no such table
-    Just  i -> case elemIndex cn $ metadata_column $ mds !! i of
-        Nothing -> (-1, 0) -- no such table
-        Just  j -> (i, j)

--- a/src/frontend/compiler/src/CodeGenerator/Expr.hs
+++ b/src/frontend/compiler/src/CodeGenerator/Expr.hs
@@ -60,9 +60,9 @@ exprBetween :: Expr -> Expr -> Expr -> CodeGenEnv
 exprBetween a b c = getLabel >>= \labelAva
     -> updateLabel
     >> cExpr a >> dup                                            -- stack: a,a
-    >> cExpr c >> appendInst (Instruction opJGe 0 labelAva "")   -- stack: a,a,c -> a
+    >> cExpr c >> appendInst (Instruction opJGt 0 labelAva "")   -- stack: a,a,c -> a
     >> dup                                                       -- stack: a,a
-    >> cExpr b >> appendInst (Instruction opJLe 0 labelAva "")   -- stack: a,a,b -> a
+    >> cExpr b >> appendInst (Instruction opJLt 0 labelAva "")   -- stack: a,a,b -> a
     >> pop 1 >> putTrue
     >> getLabel >>= goto
     >> mkLabel' labelAva

--- a/src/frontend/compiler/src/CodeGenerator/Expr.hs
+++ b/src/frontend/compiler/src/CodeGenerator/Expr.hs
@@ -15,8 +15,8 @@ import Control.Monad.Except
 cExpr :: Expr -> CodeGenEnv
 cExpr = \case
     BinExpr op e1 e2
-        | op == And                                 -> exprAnd e2 e1
-        | op == Or                                  -> exprOr  e2 e1
+        | op == And                                 -> exprAnd e1 e2
+        | op == Or                                  -> exprOr  e1 e2
         | op `elem` [Plus, Minus, Divide, Multiply] -> exprArith op e1 e2
         | otherwise                                 -> exprCompr op e1 e2
     LikeExpr op e1 e2                               -> exprLike  op e1 e2

--- a/src/frontend/compiler/src/CodeGenerator/Instruction.hs
+++ b/src/frontend/compiler/src/CodeGenerator/Instruction.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 module Instruction where
 
-
+opTempInst     = "opTempInst"      --0
 opTransaction  = "opTransaction"   --1
 opCommit       = "opCommit"        --2
 opRollback     = "opRollback"      --3

--- a/src/frontend/compiler/src/Parser/Parser.hs
+++ b/src/frontend/compiler/src/Parser/Parser.hs
@@ -308,8 +308,8 @@ expr = pd1 where
             likeExpr = \x -> makeNode x <*> pd6
                 where makeNode x = matchAndRet "like" (LikeExpr Like x) <|>
                                    matchAndRet "glob" (LikeExpr Glob x) <|>
-                                   matchTwoAndRet "not" "like" (NotExpr . LikeExpr NotLike x) <|>
-                                   matchTwoAndRet "not" "glob" (NotExpr . LikeExpr NotGlob x)
+                                   matchTwoAndRet "not" "like" (LikeExpr NotLike x) <|>
+                                   matchTwoAndRet "not" "glob" (LikeExpr NotGlob x)
 
     -- pd6 ::= pd7 [(+ | -) pd7]*
     pd6 = chainl (pBinNode "+" Plus     <|> pBinNode "-" Minus ) pd7

--- a/src/frontend/compiler/src/Parser/Parser.hs
+++ b/src/frontend/compiler/src/Parser/Parser.hs
@@ -187,7 +187,11 @@ value = (ValStr <$> strValue)       <|>
 
 
 -- identification matches regex: `[_a-zA-Z]+[_a-zA-Z0-9]*`
-ident = (++)
+ident = anyIdent >>= \case
+    "null" -> alwaysFail >> return ""
+    oth    -> return oth
+
+anyIdent = (++)
     <$> (many space >> some (letter <|> char '_'))
     <*> many (letter <|> digit <|> char '_')
 
@@ -322,7 +326,7 @@ expr = pd1 where
     --       | column-name
     --       | value
     pd0 = surroundByBrackets pd1                                                                <|>
-          (TableColumn  <$> ident <*> (spcChar '.' >> ident))                                   <|>
+          (TableColumn  <$> ident <*> (spcChar '.' >> anyIdent))                                <|>
           (FunctionCall . map toLower <$> ident <*> surroundByBrackets (argsListOrEmpty pd1))   <|>
           (Column       <$> ident)                                                              <|>
           (ConstValue   <$> value)                                                              <|>

--- a/src/frontend/compiler/src/Test/Main.hs
+++ b/src/frontend/compiler/src/Test/Main.hs
@@ -4,7 +4,8 @@ module Main where
 import TestCodeGenerator
 
 import Test.HUnit
+import Control.Monad
 
 
 main :: IO ()
-main = runTestTT codeGeneratorTest >> return ()
+main = void (runTestTT codeGeneratorTest)

--- a/src/frontend/compiler/src/Test/TestCodeGenerator.hs
+++ b/src/frontend/compiler/src/Test/TestCodeGenerator.hs
@@ -3,6 +3,7 @@ module TestCodeGenerator where
 
 import Ast
 import Expr
+import Parser
 import TestUtils
 import Instruction
 import CodeGeneratorUtils
@@ -11,8 +12,10 @@ import Test.HUnit
 
 
 -- NOTE assume that
---  table xxx has 3 columns: a, b, c, x
---  table yyy has 3 columns: a, b, d, y
+--  table xxx has 4 columns: a, b, c, x
+--            has 2 indexes: idx_xxx_a: a, idx_xxx_a_b: (a, b)
+--  table yyy has 4 columns: a, b, d, y
+--            has 2 indexes: idx_yyy_d: d, idx_yyy_a_b: (a, b)
 
 codeGeneratorTest :: Test
 codeGeneratorTest =
@@ -26,19 +29,19 @@ codeGeneratorTest =
 -- Test code generator: expr
 ----------------------------------------------------------
       "table-column" ~: "wrong table name"
-                     ~: cExpr (TableColumn "zzz" "a")
+                     ~: cExpr (runParser expr "zzz.a")
                      ?: Left "No such column: zzz.a"
 
     , "table-column" ~: "wrong column name"
-                     ~: cExpr (TableColumn "xxx" "d")
+                     ~: cExpr (runParser expr "xxx.d")
                      ?: Left "No such column: xxx.d"
 
     , "table-column" ~: ""
-                     ~: cExpr (TableColumn "xxx" "b")
+                     ~: cExpr (runParser expr "xxx.b")
                      ?: Right [Instruction opColumn 0 1 ""]
 
     , "table-column" ~: ""
-                     ~: cExpr (TableColumn "yyy" "b")
+                     ~: cExpr (runParser expr "yyy.b")
                      ?: Right [Instruction opColumn 1 1 ""]
 ----------------------------------------------------------
     , "column"       ~: "wrong column name"
@@ -62,15 +65,15 @@ codeGeneratorTest =
                      ?: Right [Instruction opColumn 1 2 ""]
 ----------------------------------------------------------
     , "const value"  ~: "string"
-                     ~: cExpr (ConstValue $ ValStr "a")
+                     ~: cExpr (runParser expr "\"a\"")
                      ?: Right [Instruction opString 0 0 "a"]
 
     , "const value"  ~: "integer"
-                     ~: cExpr (ConstValue $ ValInt 123)
+                     ~: cExpr (runParser expr "123")
                      ?: Right [Instruction opInteger 123 0 ""]
 
     , "const value"  ~: "double"
-                     ~: cExpr (ConstValue $ ValDouble 12.3)
+                     ~: cExpr (runParser expr "12.3")
                      ?: Right [Instruction opString 0 0 "12.3"]
 
     , "const value"  ~: "null"
@@ -78,27 +81,27 @@ codeGeneratorTest =
                      ?: Right [Instruction opNull 0 0 ""]
 ----------------------------------------------------------
     , "binary expr"  ~: "plus (+)"
-                     ~: cExpr (BinExpr Plus (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c+d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opAdd 0 0 ""]
 
     , "binary expr"  ~: "minus (-)"
-                     ~: cExpr (BinExpr Minus (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c-d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opSubtract 0 0 ""]
 
     , "binary expr"  ~: "multiply (*)"
-                     ~: cExpr (BinExpr Multiply (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c*d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opMultiply 0 0 ""]
 
     , "binary expr"  ~: "divide (/)"
-                     ~: cExpr (BinExpr Divide (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c/d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opDivide 0 0 ""]
 
     , "binary expr"  ~: "and"
-                     ~: cExpr (BinExpr And (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c and d")
                      ?: cExpr (Column "c")
                      >: Right [Instruction opNot 0 0 ""
                               ,Instruction opJIf 0 0 ""]
@@ -112,7 +115,7 @@ codeGeneratorTest =
                               ,Instruction opNoop    0 1 ""]
 
     , "binary expr"  ~: "or"
-                     ~: cExpr (BinExpr Or (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c or d")
                      ?: cExpr (Column "c")
                      >: Right [Instruction opJIf 0 0 ""]
                      /: cExpr (Column "d")
@@ -124,91 +127,96 @@ codeGeneratorTest =
                               ,Instruction opNoop    0 1 ""]
 
     , "binary expr"  ~: "Great (>)"
-                     ~: cExpr (BinExpr Gt (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c > d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opSetGt 0 1 ""]
 
     , "binary expr"  ~: "less (<)"
-                     ~: cExpr (BinExpr Ls (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c < d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opSetLt 0 1 ""]
 
     , "binary expr"  ~: "great or equal (>=)"
-                     ~: cExpr (BinExpr GE (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c >= d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opSetGe 0 1 ""]
 
     , "binary expr"  ~: "less or equal (<=)"
-                     ~: cExpr (BinExpr LE (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c <= d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opSetLe 0 1 ""]
 
     , "binary expr"  ~: "equal (=) (==)"
-                     ~: cExpr (BinExpr Eq (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c = d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opSetEq 0 1 ""]
 
     , "binary expr"  ~: "not equal (<>) (!=)"
-                     ~: cExpr (BinExpr NE (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c <> d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opSetNe 0 1 ""]
 ----------------------------------------------------------
     , "like expr"    ~: "like"
-                     ~: cExpr (LikeExpr Like (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c like d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opSetLike 0 1 ""]
 
     , "like expr"    ~: "notlike"
-                     ~: cExpr (LikeExpr NotLike (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c notlike d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opSetLike 1 1 ""]
 
     , "like expr"    ~: "glob"
-                     ~: cExpr (LikeExpr Glob (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c glob d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opSetGlob 0 1 ""]
 
     , "like expr"    ~: "notglob"
-                     ~: cExpr (LikeExpr NotGlob (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "c notglob d")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opSetGlob 1 1 ""]
 ----------------------------------------------------------
     , "func call"    ~: "no such function"
-                     ~: cExpr (FunctionCall "asd" [])
+                     ~: cExpr (runParser expr "asd()")
                      ?: Left "No such function: asd"
 
     , "func call"    ~: "too few arguments"
-                     ~: cExpr (FunctionCall "min" [])
+                     ~: cExpr (runParser expr "min()")
                      ?: Left "Too few arguments to function: min"
 
     , "func call"    ~: "too many arguments"
-                     ~: cExpr (FunctionCall "max" [ConstValue Null, ConstValue Null, ConstValue Null])
+                     ~: cExpr (runParser expr "max(null,null,null)")
                      ?: Left "Too many arguments to function: max"
 
     , "func call"    ~: ""
-                     ~: cExpr (FunctionCall "max" [Column "c", Column "d"])
+                     ~: cExpr (runParser expr "max(c,d)")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opMax 0 0 ""]
 
     , "func call"    ~: ""
-                     ~: cExpr (FunctionCall "min" [Column "c", Column "d"])
+                     ~: cExpr (runParser expr "min(c,d)")
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opMin 0 0 ""]
 
     , "func call"    ~: ""
-                     ~: cExpr (FunctionCall "substr" [Column "c", ConstValue $ ValInt 1, ConstValue $ ValInt 2])
+                     ~: cExpr (runParser expr "substr(c,1,2)")
                      ?: cExpr (Column "c")
                      >: Right [Instruction opInteger 1 0 ""
                               ,Instruction opInteger 2 0 ""
                               ,Instruction opSubstr  0 0 ""]
 ----------------------------------------------------------
     , "is null"      ~: ""
-                     ~: cExpr (IsNull $ Column "c")
+                     ~: cExpr (runParser expr "c is null")
                      ?: cExpr (Column "c")
                      >: Right [Instruction opSetIsNull 0 1 ""]
+    , "not null"     ~: ""
+                     ~: cExpr (runParser expr "c not null")
+                     ?: cExpr (Column "c")
+                     >: Right [Instruction opSetIsNull 0 1 ""
+                              ,Instruction opNot       0 0 ""]
 ----------------------------------------------------------
     , "between"      ~: ""
-                     ~: cExpr (Between (Column "x") (Column "c") (Column "d"))
+                     ~: cExpr (runParser expr "x between c and d")
                      ?: cExpr (Column "x")
                      >: Right [Instruction opDup 0 0 ""]
                      /: cExpr (Column "d")
@@ -225,12 +233,12 @@ codeGeneratorTest =
                               ,Instruction opNoop    0 1 ""]
 ----------------------------------------------------------
     , "in expr"      ~: "empty list"
-                     ~: cExpr (InExpr (Column "x") $ ValueList [])
+                     ~: cExpr (runParser expr "x in ()")
                      ?: Right [Instruction opInteger 0 0 ""]
 
     , "in expr"      ~: ""
                      ~: putRes [Instruction opNoop 0 (-1) ""]
-                     +: cExpr (InExpr (Column "x") $ ValueList $ map (ConstValue . ValInt) [1, 2])
+                     +: cExpr (runParser expr "x in (1,2)")
                      ?: Right [Instruction opInteger 1 0 ""
                               ,Instruction opSetInsert 0 0 ""
                               ,Instruction opInteger 2 0 ""
@@ -241,36 +249,41 @@ codeGeneratorTest =
                      /: toBool
 
     , "in expr"      ~: "right-hand side of IN is not a constant (column)"
-                     ~: cExpr (InExpr (Column "x") $ ValueList [Column "x"])
+                     ~: cExpr (runParser expr "x in (x)")
                      ?: Left "Right-hand side of IN operator must be constant"
 
     , "in expr"      ~: "right-hand side of IN is not a constant (function-call)"
-                     ~: cExpr (InExpr (Column "x") $ ValueList [FunctionCall "min" [Column "x"]])
+                     ~: cExpr (runParser expr "x in (min(x))")
                      ?: Left "Right-hand side of IN operator must be constant"
 
     , "in expr"      ~: "right-hand side of IN is not a constant (bin-expr)"
-                     ~: cExpr (InExpr (Column "x") $ ValueList [BinExpr Gt (Column "x") (ConstValue Null)])
+                     ~: cExpr (runParser expr "x in (x>1)")
                      ?: Left "Right-hand side of IN operator must be constant"
 
     , "in expr"      ~: "right-hand side of IN is not a constant (like-expr)"
-                     ~: cExpr (InExpr (Column "x") $ ValueList [LikeExpr Like (Column "x") (ConstValue Null)])
+                     ~: cExpr (runParser expr "x in (x like \"a\")")
                      ?: Left "Right-hand side of IN operator must be constant"
 
     , "in expr"      ~: "right-hand side of IN is not a constant (isnull-expr)"
-                     ~: cExpr (InExpr (Column "x") $ ValueList [IsNull (Column "x")])
+                     ~: cExpr (runParser expr "x in (x is null)")
                      ?: Left "Right-hand side of IN operator must be constant"
 
     , "in expr"      ~: "right-hand side of IN is not a constant (between-expr)"
-                     ~: cExpr (InExpr (Column "x") $ ValueList [Between (Column "x") (ConstValue Null) (ConstValue Null)])
+                     ~: cExpr (runParser expr "x in (x between 1 and 2)")
                      ?: Left "Right-hand side of IN operator must be constant"
 
     , "in expr"      ~: "right-hand side of IN is not a constant (not-expr)"
-                     ~: cExpr (InExpr (Column "x") $ ValueList [NotExpr (Column "x")])
+                     ~: cExpr (runParser expr "x in (not x)")
                      ?: Left "Right-hand side of IN operator must be constant"
 ----------------------------------------------------------
     , "not expr"     ~: ""
-                     ~: cExpr (NotExpr $ Column "c")
+                     ~: cExpr (runParser expr "not c")
                      ?: cExpr (Column "c")
                      >: Right [Instruction opNot 0 0 ""]
 ----------------------------------------------------------
+-- Test code generator: cExprWrapper
+----------------------------------------------------------
+    , "test"         ~: "" -- use index idx_yyy_d and idx_xxx_a_b, eq-pair xxx.a = 3 fall back to simple expr
+                     ~: cExprWrapper (runParser Parser.expr "d = 1 + 2 and 4 = xxx.b  and xxx.a = 3 and yyy.a = 1 and yyy.b > 10")
+                     ?: Right []
     ]

--- a/src/frontend/compiler/src/Test/TestCodeGenerator.hs
+++ b/src/frontend/compiler/src/Test/TestCodeGenerator.hs
@@ -212,10 +212,10 @@ codeGeneratorTest =
                      ?: cExpr (Column "x")
                      >: Right [Instruction opDup 0 0 ""]
                      /: cExpr (Column "d")
-                     >: Right [Instruction opJGe 0 0 ""
+                     >: Right [Instruction opJGt 0 0 ""
                               ,Instruction opDup 0 0 ""]
                      /: cExpr (Column "c")
-                     >: Right [Instruction opJLe     0 0 ""
+                     >: Right [Instruction opJLt     0 0 ""
                               ,Instruction opPop     1 0 ""
                               ,Instruction opInteger 1 0 ""
                               ,Instruction opGoto    0 1 ""

--- a/src/frontend/compiler/src/Test/TestCodeGenerator.hs
+++ b/src/frontend/compiler/src/Test/TestCodeGenerator.hs
@@ -1,9 +1,6 @@
 module TestCodeGenerator where
 
 
-import Ast
-import Expr
-import Parser
 import TestUtils
 import Instruction
 import CodeGeneratorUtils
@@ -13,9 +10,11 @@ import Test.HUnit
 
 -- NOTE assume that
 --  table xxx has 4 columns: a, b, c, x
---            has 2 indexes: idx_xxx_a: a, idx_xxx_a_b: (a, b)
+--            has 2 indexes: idx_xxx_a  : a,
+--                           idx_xxx_a_b: (a, b)
 --  table yyy has 4 columns: a, b, d, y
---            has 2 indexes: idx_yyy_d: d, idx_yyy_a_b: (a, b)
+--            has 2 indexes: idx_yyy_d  : d,
+--                           idx_yyy_a_b: (a, b)
 
 codeGeneratorTest :: Test
 codeGeneratorTest =
@@ -29,83 +28,83 @@ codeGeneratorTest =
 -- Test code generator: expr
 ----------------------------------------------------------
       "table-column" ~: "wrong table name"
-                     ~: cExpr (runParser expr "zzz.a")
+                     ~: cExprStr "zzz.a"
                      ?: Left "No such column: zzz.a"
 
     , "table-column" ~: "wrong column name"
-                     ~: cExpr (runParser expr "xxx.d")
+                     ~: cExprStr "xxx.d"
                      ?: Left "No such column: xxx.d"
 
     , "table-column" ~: ""
-                     ~: cExpr (runParser expr "xxx.b")
+                     ~: cExprStr "xxx.b"
                      ?: Right [Instruction opColumn 0 1 ""]
 
     , "table-column" ~: ""
-                     ~: cExpr (runParser expr "yyy.b")
+                     ~: cExprStr "yyy.b"
                      ?: Right [Instruction opColumn 1 1 ""]
 ----------------------------------------------------------
     , "column"       ~: "wrong column name"
-                     ~: cExpr (Column "e")
+                     ~: cExprStr "e"
                      ?: Left "No such column: e"
 
     , "column"       ~: "anbigous column name"
-                     ~: cExpr (Column "a")
+                     ~: cExprStr "a"
                      ?: Left "Ambiguous column name: a"
 
     , "column"       ~: "anbigous column name"
-                     ~: cExpr (Column "b")
+                     ~: cExprStr "b"
                      ?: Left "Ambiguous column name: b"
 
     , "column"       ~: ""
-                     ~: cExpr (Column "c")
+                     ~: cExprStr "c"
                      ?: Right [Instruction opColumn 0 2 ""]
 
     , "column"       ~: ""
-                     ~: cExpr (Column "d")
+                     ~: cExprStr "d"
                      ?: Right [Instruction opColumn 1 2 ""]
 ----------------------------------------------------------
     , "const value"  ~: "string"
-                     ~: cExpr (runParser expr "\"a\"")
+                     ~: cExprStr "\"a\""
                      ?: Right [Instruction opString 0 0 "a"]
 
     , "const value"  ~: "integer"
-                     ~: cExpr (runParser expr "123")
+                     ~: cExprStr "123"
                      ?: Right [Instruction opInteger 123 0 ""]
 
     , "const value"  ~: "double"
-                     ~: cExpr (runParser expr "12.3")
+                     ~: cExprStr "12.3"
                      ?: Right [Instruction opString 0 0 "12.3"]
 
     , "const value"  ~: "null"
-                     ~: cExpr (ConstValue Null)
+                     ~: cExprStr "null"
                      ?: Right [Instruction opNull 0 0 ""]
 ----------------------------------------------------------
     , "binary expr"  ~: "plus (+)"
-                     ~: cExpr (runParser expr "c+d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c+d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opAdd 0 0 ""]
 
     , "binary expr"  ~: "minus (-)"
-                     ~: cExpr (runParser expr "c-d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c-d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opSubtract 0 0 ""]
 
     , "binary expr"  ~: "multiply (*)"
-                     ~: cExpr (runParser expr "c*d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c*d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opMultiply 0 0 ""]
 
     , "binary expr"  ~: "divide (/)"
-                     ~: cExpr (runParser expr "c/d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c/d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opDivide 0 0 ""]
 
     , "binary expr"  ~: "and"
-                     ~: cExpr (runParser expr "c and d")
-                     ?: cExpr (Column "c")
+                     ~: cExprStr "c and d"
+                     ?: cExprStr "d"
                      >: Right [Instruction opNot 0 0 ""
                               ,Instruction opJIf 0 0 ""]
-                     /: cExpr (Column "d")
+                     /: cExprStr "c"
                      >: Right [Instruction opNot     0 0 ""
                               ,Instruction opJIf     0 0 ""
                               ,Instruction opInteger 1 0 ""
@@ -115,10 +114,10 @@ codeGeneratorTest =
                               ,Instruction opNoop    0 1 ""]
 
     , "binary expr"  ~: "or"
-                     ~: cExpr (runParser expr "c or d")
-                     ?: cExpr (Column "c")
+                     ~: cExprStr "c or d"
+                     ?: cExprStr "d"
                      >: Right [Instruction opJIf 0 0 ""]
-                     /: cExpr (Column "d")
+                     /: cExprStr "c"
                      >: Right [Instruction opJIf     0 0 ""
                               ,Instruction opInteger 0 0 ""
                               ,Instruction opGoto    0 1 ""
@@ -127,102 +126,102 @@ codeGeneratorTest =
                               ,Instruction opNoop    0 1 ""]
 
     , "binary expr"  ~: "Great (>)"
-                     ~: cExpr (runParser expr "c > d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c > d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opSetGt 0 1 ""]
 
     , "binary expr"  ~: "less (<)"
-                     ~: cExpr (runParser expr "c < d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c < d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opSetLt 0 1 ""]
 
     , "binary expr"  ~: "great or equal (>=)"
-                     ~: cExpr (runParser expr "c >= d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c >= d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opSetGe 0 1 ""]
 
     , "binary expr"  ~: "less or equal (<=)"
-                     ~: cExpr (runParser expr "c <= d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c <= d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opSetLe 0 1 ""]
 
     , "binary expr"  ~: "equal (=) (==)"
-                     ~: cExpr (runParser expr "c = d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c = d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opSetEq 0 1 ""]
 
     , "binary expr"  ~: "not equal (<>) (!=)"
-                     ~: cExpr (runParser expr "c <> d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c <> d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opSetNe 0 1 ""]
 ----------------------------------------------------------
     , "like expr"    ~: "like"
-                     ~: cExpr (runParser expr "c like d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c like d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opSetLike 0 1 ""]
 
     , "like expr"    ~: "notlike"
-                     ~: cExpr (runParser expr "c notlike d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c notlike d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opSetLike 1 1 ""]
 
     , "like expr"    ~: "glob"
-                     ~: cExpr (runParser expr "c glob d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c glob d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opSetGlob 0 1 ""]
 
     , "like expr"    ~: "notglob"
-                     ~: cExpr (runParser expr "c notglob d")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "c notglob d"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opSetGlob 1 1 ""]
 ----------------------------------------------------------
     , "func call"    ~: "no such function"
-                     ~: cExpr (runParser expr "asd()")
+                     ~: cExprStr "asd()"
                      ?: Left "No such function: asd"
 
     , "func call"    ~: "too few arguments"
-                     ~: cExpr (runParser expr "min()")
+                     ~: cExprStr "min()"
                      ?: Left "Too few arguments to function: min"
 
     , "func call"    ~: "too many arguments"
-                     ~: cExpr (runParser expr "max(null,null,null)")
+                     ~: cExprStr "max(null,null,null)"
                      ?: Left "Too many arguments to function: max"
 
     , "func call"    ~: ""
-                     ~: cExpr (runParser expr "max(c,d)")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "max(c,d)"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opMax 0 0 ""]
 
     , "func call"    ~: ""
-                     ~: cExpr (runParser expr "min(c,d)")
-                     ?: cExpr (Column "c") +: cExpr (Column "d")
+                     ~: cExprStr "min(c,d)"
+                     ?: cExprStr "c" +: cExprStr "d"
                      >: Right [Instruction opMin 0 0 ""]
 
     , "func call"    ~: ""
-                     ~: cExpr (runParser expr "substr(c,1,2)")
-                     ?: cExpr (Column "c")
+                     ~: cExprStr "substr(c,1,2)"
+                     ?: cExprStr "c"
                      >: Right [Instruction opInteger 1 0 ""
                               ,Instruction opInteger 2 0 ""
                               ,Instruction opSubstr  0 0 ""]
 ----------------------------------------------------------
     , "is null"      ~: ""
-                     ~: cExpr (runParser expr "c is null")
-                     ?: cExpr (Column "c")
+                     ~: cExprStr "c is null"
+                     ?: cExprStr "c"
                      >: Right [Instruction opSetIsNull 0 1 ""]
     , "not null"     ~: ""
-                     ~: cExpr (runParser expr "c not null")
-                     ?: cExpr (Column "c")
+                     ~: cExprStr "c not null"
+                     ?: cExprStr "c"
                      >: Right [Instruction opSetIsNull 0 1 ""
                               ,Instruction opNot       0 0 ""]
 ----------------------------------------------------------
     , "between"      ~: ""
-                     ~: cExpr (runParser expr "x between c and d")
-                     ?: cExpr (Column "x")
+                     ~: cExprStr "x between c and d"
+                     ?: cExprStr "x"
                      >: Right [Instruction opDup 0 0 ""]
-                     /: cExpr (Column "d")
+                     /: cExprStr "d"
                      >: Right [Instruction opJGt 0 0 ""
                               ,Instruction opDup 0 0 ""]
-                     /: cExpr (Column "c")
+                     /: cExprStr "c"
                      >: Right [Instruction opJLt     0 0 ""
                               ,Instruction opPop     1 0 ""
                               ,Instruction opInteger 1 0 ""
@@ -233,57 +232,111 @@ codeGeneratorTest =
                               ,Instruction opNoop    0 1 ""]
 ----------------------------------------------------------
     , "in expr"      ~: "empty list"
-                     ~: cExpr (runParser expr "x in ()")
+                     ~: cExprStr "x in ()"
                      ?: Right [Instruction opInteger 0 0 ""]
 
     , "in expr"      ~: ""
                      ~: putRes [Instruction opNoop 0 (-1) ""]
-                     +: cExpr (runParser expr "x in (1,2)")
+                     +: cExprStr "x in (1,2)"
                      ?: Right [Instruction opInteger 1 0 ""
                               ,Instruction opSetInsert 0 0 ""
                               ,Instruction opInteger 2 0 ""
                               ,Instruction opSetInsert 0 0 ""
                               ,Instruction opNoop 0 (-1) ""]
-                     /: cExpr (Column "x")
+                     /: cExprStr "x"
                      >: Right [Instruction opSetFound 0 0 ""]
                      /: toBool
 
     , "in expr"      ~: "right-hand side of IN is not a constant (column)"
-                     ~: cExpr (runParser expr "x in (x)")
+                     ~: cExprStr "x in (x)"
                      ?: Left "Right-hand side of IN operator must be constant"
 
     , "in expr"      ~: "right-hand side of IN is not a constant (function-call)"
-                     ~: cExpr (runParser expr "x in (min(x))")
+                     ~: cExprStr "x in (min(x))"
                      ?: Left "Right-hand side of IN operator must be constant"
 
     , "in expr"      ~: "right-hand side of IN is not a constant (bin-expr)"
-                     ~: cExpr (runParser expr "x in (x>1)")
+                     ~: cExprStr "x in (x>1)"
                      ?: Left "Right-hand side of IN operator must be constant"
 
     , "in expr"      ~: "right-hand side of IN is not a constant (like-expr)"
-                     ~: cExpr (runParser expr "x in (x like \"a\")")
+                     ~: cExprStr "x in (x like \"a\")"
                      ?: Left "Right-hand side of IN operator must be constant"
 
     , "in expr"      ~: "right-hand side of IN is not a constant (isnull-expr)"
-                     ~: cExpr (runParser expr "x in (x is null)")
+                     ~: cExprStr "x in (x is null)"
                      ?: Left "Right-hand side of IN operator must be constant"
 
     , "in expr"      ~: "right-hand side of IN is not a constant (between-expr)"
-                     ~: cExpr (runParser expr "x in (x between 1 and 2)")
+                     ~: cExprStr "x in (x between 1 and 2)"
                      ?: Left "Right-hand side of IN operator must be constant"
 
     , "in expr"      ~: "right-hand side of IN is not a constant (not-expr)"
-                     ~: cExpr (runParser expr "x in (not x)")
+                     ~: cExprStr "x in (not x)"
                      ?: Left "Right-hand side of IN operator must be constant"
 ----------------------------------------------------------
     , "not expr"     ~: ""
-                     ~: cExpr (runParser expr "not c")
-                     ?: cExpr (Column "c")
+                     ~: cExprStr "not c"
+                     ?: cExprStr "c"
                      >: Right [Instruction opNot 0 0 ""]
 ----------------------------------------------------------
 -- Test code generator: cExprWrapper
 ----------------------------------------------------------
-    , "test"         ~: "" -- use index idx_yyy_d and idx_xxx_a_b, eq-pair xxx.a = 3 fall back to simple expr
-                     ~: cExprWrapper (runParser Parser.expr "d = 1 + 2 and 4 = xxx.b  and xxx.a = 3 and yyy.a = 1 and yyy.b > 10")
-                     ?: Right []
+    , "test index"   ~: "" -- use index idx_yyy_d and idx_xxx_a_b, eq-pair xxx.a = 3 fall back to simple expr
+                           -- index: (xxx.a, xxx.b) = (3, 4)
+                           -- index: yyy.d = 1 + 2
+                           -- cond : yyy.a = 1 and yyy.b > 10
+                     ~: cExprWrapperStr "d = 1 + 2 and 4 = xxx.b  and xxx.a = 3 and yyy.a = 1 and yyy.b > 10"
+                     ?: Right [Instruction opOpen     0 0 "xxx"
+                              ,Instruction opOpen     1 0 "yyy"
+                              ,Instruction opOpen     2 0 "idx_xxx_a_b"
+                              ,Instruction opOpen     3 0 "idx_yyy_d"
+                              ,Instruction opInteger  3 0 ""
+                              ,Instruction opInteger  4 0 ""
+                              ,Instruction opMakeKey  2 0 ""
+                              ,Instruction opBeginIdx 2 0 ""
+                              ,Instruction opNoop     0 1 ""
+                              ,Instruction opNextIdx  2 0 ""
+                              ,Instruction opMoveTo   0 0 ""]
+                     /: cExprStr "1+2"
+                     >: Right [Instruction opMakeKey  1 0 ""
+                              ,Instruction opBeginIdx 3 0 ""
+                              ,Instruction opNoop     0 2 ""
+                              ,Instruction opNextIdx  3 1 ""
+                              ,Instruction opMoveTo   1 0 ""]
+                     /: (putLabel 3 >> cExprStr "yyy.a = 1 and yyy.b>10")
+                     >: Right [Instruction opNot      0 0 ""
+                              ,Instruction opJIf      0 2 ""
+                              ,Instruction opTempInst 0 0 ""
+                              ,Instruction opGoto     0 2 ""
+                              ,Instruction opNoop     0 0 ""
+                              ,Instruction opClose    0 0 ""
+                              ,Instruction opClose    1 0 ""
+                              ,Instruction opClose    2 0 ""
+                              ,Instruction opClose    3 0 ""]
+    , "test index"   ~: "" -- only use index idx_yyy_d
+                           -- index: yyy.d = 1
+                           -- cond : xxx.b > 10 and yyy.a > 9
+                     ~: cExprWrapperStr "xxx.b > 10 and d = 1 and yyy.a > 9"
+                     ?: Right [Instruction opOpen     0 0 "xxx"
+                              ,Instruction opOpen     1 0 "yyy"
+                              ,Instruction opOpen     2 0 "idx_yyy_d"
+                              ,Instruction opInteger  1 0 ""
+                              ,Instruction opMakeKey  1 0 ""
+                              ,Instruction opBeginIdx 2 0 ""
+                              ,Instruction opNoop     0 1 ""
+                              ,Instruction opNextIdx  2 0 ""
+                              ,Instruction opMoveTo   1 0 ""
+                              ,Instruction opRewind   0 0 ""
+                              ,Instruction opNoop     0 2 ""
+                              ,Instruction opNext     0 1 ""]
+                     /: (putLabel 3 >> cExprStr "xxx.b > 10 and yyy.a > 9")
+                     >: Right [Instruction opNot      0 0 ""
+                              ,Instruction opJIf      0 2 ""
+                              ,Instruction opTempInst 0 0 ""
+                              ,Instruction opGoto     0 2 ""
+                              ,Instruction opNoop     0 0 ""
+                              ,Instruction opClose    0 0 ""
+                              ,Instruction opClose    1 0 ""
+                              ,Instruction opClose    2 0 ""]
     ]

--- a/src/frontend/compiler/src/Test/TestCodeGenerator.hs
+++ b/src/frontend/compiler/src/Test/TestCodeGenerator.hs
@@ -308,7 +308,7 @@ codeGeneratorTest =
                     >: Right [Instruction opMakeKey  1 0 ""
                              ,Instruction opBeginIdx 1 0 ""
                              ,Instruction opNoop     0 3 ""]
-                    /: (putLabel 5 >> cExprStr "yyy.a = 1 and yyy.b>10")
+                    /: (putLabel 5 >> cExprStr "yyy.b>10 and yyy.a = 1")
                     >: Right [Instruction opJIf      1 4 ""
                              ,Instruction opTempInst 0 0 ""
                              ,Instruction opNoop     0 4 ""
@@ -333,7 +333,7 @@ codeGeneratorTest =
                              ,Instruction opRewind   0 0 ""
                              ,Instruction opNoop     0 3 ""
                     ]
-                    /: (putLabel 5 >> cExprStr "yyy.a > 9 and xxx.b > 10")
+                    /: (putLabel 5 >> cExprStr "xxx.b > 10 and yyy.a > 9")
                     >: Right [Instruction opJIf      1 4 ""
                              ,Instruction opTempInst 0 0 ""
                              ,Instruction opNoop     0 4 ""
@@ -353,7 +353,7 @@ codeGeneratorTest =
                              ,Instruction opNoop     0 1 ""
                              ,Instruction opRewind   1 0 ""
                              ,Instruction opNoop     0 3 ""]
-                    /: (putLabel 5 >> cExprStr "yyy.a > 9 and xxx.b > 10")
+                    /: (putLabel 5 >> cExprStr "xxx.b > 10 and yyy.a > 9")
                     >: Right [Instruction opJIf      1 4 ""
                              ,Instruction opTempInst 0 0 ""
                              ,Instruction opNoop     0 4 ""

--- a/src/frontend/compiler/src/Test/TestCodeGenerator.hs
+++ b/src/frontend/compiler/src/Test/TestCodeGenerator.hs
@@ -330,7 +330,7 @@ codeGeneratorTest =
                               ,Instruction opRewind   0 0 ""
                               ,Instruction opNoop     0 2 ""
                               ,Instruction opNext     0 1 ""]
-                     /: (putLabel 3 >> cExprStr "xxx.b > 10 and yyy.a > 9")
+                     /: (putLabel 3 >> cExprStr "yyy.a > 9 and xxx.b > 10")
                      >: Right [Instruction opNot      0 0 ""
                               ,Instruction opJIf      0 2 ""
                               ,Instruction opTempInst 0 0 ""

--- a/src/frontend/compiler/src/Test/TestCodeGenerator.hs
+++ b/src/frontend/compiler/src/Test/TestCodeGenerator.hs
@@ -102,11 +102,9 @@ codeGeneratorTest =
     , "binary expr" ~: "and"
                     ~: cExprStr "c and d"
                     ?: cExprStr "c"
-                    >: Right [Instruction opNot 0 0 ""
-                             ,Instruction opJIf 0 0 ""]
+                    >: Right [Instruction opJIf     1 0 ""]
                     /: cExprStr "d"
-                    >: Right [Instruction opNot     0 0 ""
-                             ,Instruction opJIf     0 0 ""
+                    >: Right [Instruction opJIf     1 0 ""
                              ,Instruction opInteger 1 0 ""
                              ,Instruction opGoto    0 1 ""
                              ,Instruction opNoop    0 0 ""

--- a/src/frontend/compiler/src/Test/TestCodeGenerator.hs
+++ b/src/frontend/compiler/src/Test/TestCodeGenerator.hs
@@ -101,10 +101,10 @@ codeGeneratorTest =
 
     , "binary expr" ~: "and"
                     ~: cExprStr "c and d"
-                    ?: cExprStr "d"
+                    ?: cExprStr "c"
                     >: Right [Instruction opNot 0 0 ""
                              ,Instruction opJIf 0 0 ""]
-                    /: cExprStr "c"
+                    /: cExprStr "d"
                     >: Right [Instruction opNot     0 0 ""
                              ,Instruction opJIf     0 0 ""
                              ,Instruction opInteger 1 0 ""
@@ -115,9 +115,9 @@ codeGeneratorTest =
 
     , "binary expr" ~: "or"
                     ~: cExprStr "c or d"
-                    ?: cExprStr "d"
+                    ?: cExprStr "c"
                     >: Right [Instruction opJIf 0 0 ""]
-                    /: cExprStr "c"
+                    /: cExprStr "d"
                     >: Right [Instruction opJIf     0 0 ""
                              ,Instruction opInteger 0 0 ""
                              ,Instruction opGoto    0 1 ""
@@ -299,73 +299,71 @@ codeGeneratorTest =
                           -- index: yyy.d = 1 + 2
                           -- cond : yyy.a = 1 and yyy.b > 10
                     ~: cExprWrapperStr "d = 1 + 2 and 4 = xxx.b  and xxx.a = 3 and yyy.a = 1 and yyy.b > 10"
-                    ?: Right [Instruction opOpen     0 0 "xxx"
-                             ,Instruction opOpen     1 0 "yyy"
-                             ,Instruction opOpen     2 0 "idx_xxx_a_b"
-                             ,Instruction opOpen     3 0 "idx_yyy_d"
+                    ?: Right [Instruction opOpen     0 0 "idx_xxx_a_b"
+                             ,Instruction opOpen     1 0 "idx_yyy_d"
                              ,Instruction opInteger  3 0 ""
                              ,Instruction opInteger  4 0 ""
                              ,Instruction opMakeKey  2 0 ""
-                             ,Instruction opBeginIdx 2 0 ""
-                             ,Instruction opNoop     0 1 ""
-                             ,Instruction opNextIdx  2 0 ""
-                             ,Instruction opMoveTo   0 0 ""]
+                             ,Instruction opBeginIdx 0 0 ""
+                             ,Instruction opNoop     0 1 ""]
                     /: cExprStr "1+2"
                     >: Right [Instruction opMakeKey  1 0 ""
-                             ,Instruction opBeginIdx 3 0 ""
-                             ,Instruction opNoop     0 2 ""
-                             ,Instruction opNextIdx  3 1 ""
-                             ,Instruction opMoveTo   1 0 ""]
-                    /: (putLabel 3 >> cExprStr "yyy.a = 1 and yyy.b>10")
-                    >: Right [Instruction opNot      0 0 ""
-                             ,Instruction opJIf      0 2 ""
+                             ,Instruction opBeginIdx 1 0 ""
+                             ,Instruction opNoop     0 3 ""]
+                    /: (putLabel 5 >> cExprStr "yyy.a = 1 and yyy.b>10")
+                    >: Right [Instruction opJIf      1 4 ""
                              ,Instruction opTempInst 0 0 ""
-                             ,Instruction opGoto     0 2 ""
+                             ,Instruction opNoop     0 4 ""
+                             ,Instruction opNextIdx  1 2 ""
+                             ,Instruction opGoto     0 3 ""
+                             ,Instruction opNoop     0 2 ""
+                             ,Instruction opNextIdx  0 0 ""
+                             ,Instruction opGoto     0 1 ""
                              ,Instruction opNoop     0 0 ""
                              ,Instruction opClose    0 0 ""
-                             ,Instruction opClose    1 0 ""
-                             ,Instruction opClose    2 0 ""
-                             ,Instruction opClose    3 0 ""]
+                             ,Instruction opClose    1 0 ""]
     , "test index"  ~: "" -- only use index idx_yyy_d
                           -- index: yyy.d = 1
                           -- cond : xxx.b > 10 and yyy.a > 9
                     ~: cExprWrapperStr "xxx.b > 10 and d = 1 and yyy.a > 9"
                     ?: Right [Instruction opOpen     0 0 "xxx"
-                             ,Instruction opOpen     1 0 "yyy"
-                             ,Instruction opOpen     2 0 "idx_yyy_d"
+                             ,Instruction opOpen     1 0 "idx_yyy_d"
                              ,Instruction opInteger  1 0 ""
                              ,Instruction opMakeKey  1 0 ""
-                             ,Instruction opBeginIdx 2 0 ""
+                             ,Instruction opBeginIdx 1 0 ""
                              ,Instruction opNoop     0 1 ""
-                             ,Instruction opNextIdx  2 0 ""
-                             ,Instruction opMoveTo   1 0 ""
                              ,Instruction opRewind   0 0 ""
-                             ,Instruction opNoop     0 2 ""
-                             ,Instruction opNext     0 1 ""]
-                    /: (putLabel 3 >> cExprStr "yyy.a > 9 and xxx.b > 10")
-                    >: Right [Instruction opNot      0 0 ""
-                             ,Instruction opJIf      0 2 ""
+                             ,Instruction opNoop     0 3 ""
+                    ]
+                    /: (putLabel 5 >> cExprStr "yyy.a > 9 and xxx.b > 10")
+                    >: Right [Instruction opJIf      1 4 ""
                              ,Instruction opTempInst 0 0 ""
-                             ,Instruction opGoto     0 2 ""
+                             ,Instruction opNoop     0 4 ""
+                             ,Instruction opNext     0 2 ""
+                             ,Instruction opGoto     0 3 ""
+                             ,Instruction opNoop     0 2 ""
+                             ,Instruction opNextIdx  1 0 ""
+                             ,Instruction opGoto     0 1 ""
                              ,Instruction opNoop     0 0 ""
                              ,Instruction opClose    0 0 ""
-                             ,Instruction opClose    1 0 ""
-                             ,Instruction opClose    2 0 ""]
+                             ,Instruction opClose    1 0 ""]
     , "test index"  ~: "no index"
                     ~: cExprWrapperStr "xxx.b > 10 and yyy.a > 9"
                     ?: Right [Instruction opOpen     0 0 "xxx"
                              ,Instruction opOpen     1 0 "yyy"
                              ,Instruction opRewind   0 0 ""
                              ,Instruction opNoop     0 1 ""
-                             ,Instruction opNext     0 0 ""
                              ,Instruction opRewind   1 0 ""
-                             ,Instruction opNoop     0 2 ""
-                             ,Instruction opNext     1 1 ""]
-                    /: (putLabel 3 >> cExprStr "yyy.a > 9 and xxx.b > 10")
-                    >: Right [Instruction opNot      0 0 ""
-                             ,Instruction opJIf      0 2 ""
+                             ,Instruction opNoop     0 3 ""]
+                    /: (putLabel 5 >> cExprStr "yyy.a > 9 and xxx.b > 10")
+                    >: Right [Instruction opJIf      1 4 ""
                              ,Instruction opTempInst 0 0 ""
-                             ,Instruction opGoto     0 2 ""
+                             ,Instruction opNoop     0 4 ""
+                             ,Instruction opNext     1 2 ""
+                             ,Instruction opGoto     0 3 ""
+                             ,Instruction opNoop     0 2 ""
+                             ,Instruction opNext     0 0 ""
+                             ,Instruction opGoto     0 1 ""
                              ,Instruction opNoop     0 0 ""
                              ,Instruction opClose    0 0 ""
                              ,Instruction opClose    1 0 ""]

--- a/src/frontend/compiler/src/Test/TestCodeGenerator.hs
+++ b/src/frontend/compiler/src/Test/TestCodeGenerator.hs
@@ -27,316 +27,347 @@ codeGeneratorTest =
 ----------------------------------------------------------
 -- Test code generator: expr
 ----------------------------------------------------------
-      "table-column" ~: "wrong table name"
-                     ~: cExprStr "zzz.a"
-                     ?: Left "No such column: zzz.a"
+      "tb column"   ~: "wrong table name"
+                    ~: cExprStr "zzz.a"
+                    ?: Left "No such column: zzz.a"
 
-    , "table-column" ~: "wrong column name"
-                     ~: cExprStr "xxx.d"
-                     ?: Left "No such column: xxx.d"
+    , "tb column"   ~: "wrong column name"
+                    ~: cExprStr "xxx.d"
+                    ?: Left "No such column: xxx.d"
 
-    , "table-column" ~: ""
-                     ~: cExprStr "xxx.b"
-                     ?: Right [Instruction opColumn 0 1 ""]
+    , "tb column"   ~: ""
+                    ~: cExprStr "xxx.b"
+                    ?: Right [Instruction opColumn 0 1 ""]
 
-    , "table-column" ~: ""
-                     ~: cExprStr "yyy.b"
-                     ?: Right [Instruction opColumn 1 1 ""]
+    , "tb column"   ~: ""
+                    ~: cExprStr "yyy.b"
+                    ?: Right [Instruction opColumn 1 1 ""]
 ----------------------------------------------------------
-    , "column"       ~: "wrong column name"
-                     ~: cExprStr "e"
-                     ?: Left "No such column: e"
+    , "column"      ~: "wrong column name"
+                    ~: cExprStr "e"
+                    ?: Left "No such column: e"
 
-    , "column"       ~: "anbigous column name"
-                     ~: cExprStr "a"
-                     ?: Left "Ambiguous column name: a"
+    , "column"      ~: "anbigous column name"
+                    ~: cExprStr "a"
+                    ?: Left "Ambiguous column name: a"
 
-    , "column"       ~: "anbigous column name"
-                     ~: cExprStr "b"
-                     ?: Left "Ambiguous column name: b"
+    , "column"      ~: "anbigous column name"
+                    ~: cExprStr "b"
+                    ?: Left "Ambiguous column name: b"
 
-    , "column"       ~: ""
-                     ~: cExprStr "c"
-                     ?: Right [Instruction opColumn 0 2 ""]
+    , "column"      ~: ""
+                    ~: cExprStr "c"
+                    ?: Right [Instruction opColumn 0 2 ""]
 
-    , "column"       ~: ""
-                     ~: cExprStr "d"
-                     ?: Right [Instruction opColumn 1 2 ""]
+    , "column"      ~: ""
+                    ~: cExprStr "d"
+                    ?: Right [Instruction opColumn 1 2 ""]
+---------------------------------------------------------
+    , "const value" ~: "string"
+                    ~: cExprStr "\"a\""
+                    ?: Right [Instruction opString 0 0 "a"]
+
+    , "const value" ~: "integer"
+                    ~: cExprStr "123"
+                    ?: Right [Instruction opInteger 123 0 ""]
+
+    , "const value" ~: "double"
+                    ~: cExprStr "12.3"
+                    ?: Right [Instruction opString 0 0 "12.3"]
+
+    , "const value" ~: "null"
+                    ~: cExprStr "null"
+                    ?: Right [Instruction opNull 0 0 ""]
 ----------------------------------------------------------
-    , "const value"  ~: "string"
-                     ~: cExprStr "\"a\""
-                     ?: Right [Instruction opString 0 0 "a"]
+    , "binary expr" ~: "plus (+)"
+                    ~: cExprStr "c+d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opAdd 0 0 ""]
 
-    , "const value"  ~: "integer"
-                     ~: cExprStr "123"
-                     ?: Right [Instruction opInteger 123 0 ""]
+    , "binary expr" ~: "minus (-)"
+                    ~: cExprStr "c-d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opSubtract 0 0 ""]
 
-    , "const value"  ~: "double"
-                     ~: cExprStr "12.3"
-                     ?: Right [Instruction opString 0 0 "12.3"]
+    , "binary expr" ~: "multiply (*)"
+                    ~: cExprStr "c*d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opMultiply 0 0 ""]
 
-    , "const value"  ~: "null"
-                     ~: cExprStr "null"
-                     ?: Right [Instruction opNull 0 0 ""]
+    , "binary expr" ~: "divide (/)"
+                    ~: cExprStr "c/d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opDivide 0 0 ""]
+
+    , "binary expr" ~: "and"
+                    ~: cExprStr "c and d"
+                    ?: cExprStr "d"
+                    >: Right [Instruction opNot 0 0 ""
+                             ,Instruction opJIf 0 0 ""]
+                    /: cExprStr "c"
+                    >: Right [Instruction opNot     0 0 ""
+                             ,Instruction opJIf     0 0 ""
+                             ,Instruction opInteger 1 0 ""
+                             ,Instruction opGoto    0 1 ""
+                             ,Instruction opNoop    0 0 ""
+                             ,Instruction opInteger 0 0 ""
+                             ,Instruction opNoop    0 1 ""]
+
+    , "binary expr" ~: "or"
+                    ~: cExprStr "c or d"
+                    ?: cExprStr "d"
+                    >: Right [Instruction opJIf 0 0 ""]
+                    /: cExprStr "c"
+                    >: Right [Instruction opJIf     0 0 ""
+                             ,Instruction opInteger 0 0 ""
+                             ,Instruction opGoto    0 1 ""
+                             ,Instruction opNoop    0 0 ""
+                             ,Instruction opInteger 1 0 ""
+                             ,Instruction opNoop    0 1 ""]
+
+    , "binary expr" ~: "Great (>)"
+                    ~: cExprStr "c > d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opSetGt 0 1 ""]
+
+    , "binary expr" ~: "less (<)"
+                    ~: cExprStr "c < d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opSetLt 0 1 ""]
+
+    , "binary expr" ~: "great or equal (>=)"
+                    ~: cExprStr "c >= d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opSetGe 0 1 ""]
+
+    , "binary expr" ~: "less or equal (<=)"
+                    ~: cExprStr "c <= d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opSetLe 0 1 ""]
+
+    , "binary expr" ~: "equal (=) (==)"
+                    ~: cExprStr "c = d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opSetEq 0 1 ""]
+
+    , "binary expr" ~: "not equal (<>) (!=)"
+                    ~: cExprStr "c <> d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opSetNe 0 1 ""]
 ----------------------------------------------------------
-    , "binary expr"  ~: "plus (+)"
-                     ~: cExprStr "c+d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opAdd 0 0 ""]
+    , "like expr"   ~: "like"
+                    ~: cExprStr "c like d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opSetLike 0 1 ""]
 
-    , "binary expr"  ~: "minus (-)"
-                     ~: cExprStr "c-d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opSubtract 0 0 ""]
+    , "like expr"   ~: "notlike"
+                    ~: cExprStr "c notlike d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opSetLike 1 1 ""]
 
-    , "binary expr"  ~: "multiply (*)"
-                     ~: cExprStr "c*d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opMultiply 0 0 ""]
+    , "like expr"   ~: "glob"
+                    ~: cExprStr "c glob d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opSetGlob 0 1 ""]
 
-    , "binary expr"  ~: "divide (/)"
-                     ~: cExprStr "c/d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opDivide 0 0 ""]
-
-    , "binary expr"  ~: "and"
-                     ~: cExprStr "c and d"
-                     ?: cExprStr "d"
-                     >: Right [Instruction opNot 0 0 ""
-                              ,Instruction opJIf 0 0 ""]
-                     /: cExprStr "c"
-                     >: Right [Instruction opNot     0 0 ""
-                              ,Instruction opJIf     0 0 ""
-                              ,Instruction opInteger 1 0 ""
-                              ,Instruction opGoto    0 1 ""
-                              ,Instruction opNoop    0 0 ""
-                              ,Instruction opInteger 0 0 ""
-                              ,Instruction opNoop    0 1 ""]
-
-    , "binary expr"  ~: "or"
-                     ~: cExprStr "c or d"
-                     ?: cExprStr "d"
-                     >: Right [Instruction opJIf 0 0 ""]
-                     /: cExprStr "c"
-                     >: Right [Instruction opJIf     0 0 ""
-                              ,Instruction opInteger 0 0 ""
-                              ,Instruction opGoto    0 1 ""
-                              ,Instruction opNoop    0 0 ""
-                              ,Instruction opInteger 1 0 ""
-                              ,Instruction opNoop    0 1 ""]
-
-    , "binary expr"  ~: "Great (>)"
-                     ~: cExprStr "c > d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opSetGt 0 1 ""]
-
-    , "binary expr"  ~: "less (<)"
-                     ~: cExprStr "c < d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opSetLt 0 1 ""]
-
-    , "binary expr"  ~: "great or equal (>=)"
-                     ~: cExprStr "c >= d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opSetGe 0 1 ""]
-
-    , "binary expr"  ~: "less or equal (<=)"
-                     ~: cExprStr "c <= d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opSetLe 0 1 ""]
-
-    , "binary expr"  ~: "equal (=) (==)"
-                     ~: cExprStr "c = d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opSetEq 0 1 ""]
-
-    , "binary expr"  ~: "not equal (<>) (!=)"
-                     ~: cExprStr "c <> d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opSetNe 0 1 ""]
+    , "like expr"   ~: "notglob"
+                    ~: cExprStr "c notglob d"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opSetGlob 1 1 ""]
 ----------------------------------------------------------
-    , "like expr"    ~: "like"
-                     ~: cExprStr "c like d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opSetLike 0 1 ""]
+    , "func call"   ~: "no such function"
+                    ~: cExprStr "asd()"
+                    ?: Left "No such function: asd"
 
-    , "like expr"    ~: "notlike"
-                     ~: cExprStr "c notlike d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opSetLike 1 1 ""]
+    , "func call"   ~: "too few arguments"
+                    ~: cExprStr "min()"
+                    ?: Left "Too few arguments to function: min"
 
-    , "like expr"    ~: "glob"
-                     ~: cExprStr "c glob d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opSetGlob 0 1 ""]
+    , "func call"   ~: "too many arguments"
+                    ~: cExprStr "max(null,null,null)"
+                    ?: Left "Too many arguments to function: max"
 
-    , "like expr"    ~: "notglob"
-                     ~: cExprStr "c notglob d"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opSetGlob 1 1 ""]
+    , "func call"   ~: ""
+                    ~: cExprStr "max(c,d)"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opMax 0 0 ""]
+
+    , "func call"   ~: ""
+                    ~: cExprStr "min(c,d)"
+                    ?: cExprStr "c" +: cExprStr "d"
+                    >: Right [Instruction opMin 0 0 ""]
+
+    , "func call"   ~: ""
+                    ~: cExprStr "substr(c,1,2)"
+                    ?: cExprStr "c"
+                    >: Right [Instruction opInteger 1 0 ""
+                             ,Instruction opInteger 2 0 ""
+                             ,Instruction opSubstr  0 0 ""]
 ----------------------------------------------------------
-    , "func call"    ~: "no such function"
-                     ~: cExprStr "asd()"
-                     ?: Left "No such function: asd"
-
-    , "func call"    ~: "too few arguments"
-                     ~: cExprStr "min()"
-                     ?: Left "Too few arguments to function: min"
-
-    , "func call"    ~: "too many arguments"
-                     ~: cExprStr "max(null,null,null)"
-                     ?: Left "Too many arguments to function: max"
-
-    , "func call"    ~: ""
-                     ~: cExprStr "max(c,d)"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opMax 0 0 ""]
-
-    , "func call"    ~: ""
-                     ~: cExprStr "min(c,d)"
-                     ?: cExprStr "c" +: cExprStr "d"
-                     >: Right [Instruction opMin 0 0 ""]
-
-    , "func call"    ~: ""
-                     ~: cExprStr "substr(c,1,2)"
-                     ?: cExprStr "c"
-                     >: Right [Instruction opInteger 1 0 ""
-                              ,Instruction opInteger 2 0 ""
-                              ,Instruction opSubstr  0 0 ""]
+    , "is null"     ~: ""
+                    ~: cExprStr "c is null"
+                    ?: cExprStr "c"
+                    >: Right [Instruction opSetIsNull 0 1 ""]
+    , "not null"    ~: ""
+                    ~: cExprStr "c not null"
+                    ?: cExprStr "c"
+                    >: Right [Instruction opSetIsNull 0 1 ""
+                             ,Instruction opNot       0 0 ""]
 ----------------------------------------------------------
-    , "is null"      ~: ""
-                     ~: cExprStr "c is null"
-                     ?: cExprStr "c"
-                     >: Right [Instruction opSetIsNull 0 1 ""]
-    , "not null"     ~: ""
-                     ~: cExprStr "c not null"
-                     ?: cExprStr "c"
-                     >: Right [Instruction opSetIsNull 0 1 ""
-                              ,Instruction opNot       0 0 ""]
+    , "between"     ~: ""
+                    ~: cExprStr "x between c and d"
+                    ?: cExprStr "x"
+                    >: Right [Instruction opDup 0 0 ""]
+                    /: cExprStr "d"
+                    >: Right [Instruction opJGt 0 0 ""
+                             ,Instruction opDup 0 0 ""]
+                    /: cExprStr "c"
+                    >: Right [Instruction opJLt     0 0 ""
+                             ,Instruction opPop     1 0 ""
+                             ,Instruction opInteger 1 0 ""
+                             ,Instruction opGoto    0 1 ""
+                             ,Instruction opNoop    0 0 ""
+                             ,Instruction opPop     1 0 ""
+                             ,Instruction opInteger 0 0 ""
+                             ,Instruction opNoop    0 1 ""]
 ----------------------------------------------------------
-    , "between"      ~: ""
-                     ~: cExprStr "x between c and d"
-                     ?: cExprStr "x"
-                     >: Right [Instruction opDup 0 0 ""]
-                     /: cExprStr "d"
-                     >: Right [Instruction opJGt 0 0 ""
-                              ,Instruction opDup 0 0 ""]
-                     /: cExprStr "c"
-                     >: Right [Instruction opJLt     0 0 ""
-                              ,Instruction opPop     1 0 ""
-                              ,Instruction opInteger 1 0 ""
-                              ,Instruction opGoto    0 1 ""
-                              ,Instruction opNoop    0 0 ""
-                              ,Instruction opPop     1 0 ""
-                              ,Instruction opInteger 0 0 ""
-                              ,Instruction opNoop    0 1 ""]
-----------------------------------------------------------
-    , "in expr"      ~: "empty list"
-                     ~: cExprStr "x in ()"
-                     ?: Right [Instruction opInteger 0 0 ""]
+    , "in expr"     ~: "empty list"
+                    ~: cExprStr "x in ()"
+                    ?: Right [Instruction opInteger 0 0 ""]
 
-    , "in expr"      ~: ""
-                     ~: putRes [Instruction opNoop 0 (-1) ""]
-                     +: cExprStr "x in (1,2)"
-                     ?: Right [Instruction opInteger 1 0 ""
-                              ,Instruction opSetInsert 0 0 ""
-                              ,Instruction opInteger 2 0 ""
-                              ,Instruction opSetInsert 0 0 ""
-                              ,Instruction opNoop 0 (-1) ""]
-                     /: cExprStr "x"
-                     >: Right [Instruction opSetFound 0 0 ""]
-                     /: toBool
+    , "in expr"     ~: ""
+                    ~: putRes [Instruction opNoop 0 (-1) ""]
+                    +: cExprStr "x in (1,2)"
+                    ?: Right [Instruction opInteger 1 0 ""
+                             ,Instruction opSetInsert 0 0 ""
+                             ,Instruction opInteger 2 0 ""
+                             ,Instruction opSetInsert 0 0 ""
+                             ,Instruction opNoop 0 (-1) ""]
+                    /: cExprStr "x"
+                    >: Right [Instruction opSetFound 0 0 ""]
+                    /: toBool
 
-    , "in expr"      ~: "right-hand side of IN is not a constant (column)"
-                     ~: cExprStr "x in (x)"
-                     ?: Left "Right-hand side of IN operator must be constant"
+    , "in expr"     ~: "right-hand side of IN is not a constant (column)"
+                    ~: cExprStr "x in (x)"
+                    ?: Left "Right-hand side of IN operator must be constant"
 
-    , "in expr"      ~: "right-hand side of IN is not a constant (function-call)"
-                     ~: cExprStr "x in (min(x))"
-                     ?: Left "Right-hand side of IN operator must be constant"
+    , "in expr"     ~: "right-hand side of IN is not a constant (function-call)"
+                    ~: cExprStr "x in (min(x))"
+                    ?: Left "Right-hand side of IN operator must be constant"
 
-    , "in expr"      ~: "right-hand side of IN is not a constant (bin-expr)"
-                     ~: cExprStr "x in (x>1)"
-                     ?: Left "Right-hand side of IN operator must be constant"
+    , "in expr"     ~: "right-hand side of IN is not a constant (bin-expr)"
+                    ~: cExprStr "x in (x>1)"
+                    ?: Left "Right-hand side of IN operator must be constant"
 
-    , "in expr"      ~: "right-hand side of IN is not a constant (like-expr)"
-                     ~: cExprStr "x in (x like \"a\")"
-                     ?: Left "Right-hand side of IN operator must be constant"
+    , "in expr"     ~: "right-hand side of IN is not a constant (like-expr)"
+                    ~: cExprStr "x in (x like \"a\")"
+                    ?: Left "Right-hand side of IN operator must be constant"
 
-    , "in expr"      ~: "right-hand side of IN is not a constant (isnull-expr)"
-                     ~: cExprStr "x in (x is null)"
-                     ?: Left "Right-hand side of IN operator must be constant"
+    , "in expr"     ~: "right-hand side of IN is not a constant (isnull-expr)"
+                    ~: cExprStr "x in (x is null)"
+                    ?: Left "Right-hand side of IN operator must be constant"
 
-    , "in expr"      ~: "right-hand side of IN is not a constant (between-expr)"
-                     ~: cExprStr "x in (x between 1 and 2)"
-                     ?: Left "Right-hand side of IN operator must be constant"
+    , "in expr"     ~: "right-hand side of IN is not a constant (between-expr)"
+                    ~: cExprStr "x in (x between 1 and 2)"
+                    ?: Left "Right-hand side of IN operator must be constant"
 
-    , "in expr"      ~: "right-hand side of IN is not a constant (not-expr)"
-                     ~: cExprStr "x in (not x)"
-                     ?: Left "Right-hand side of IN operator must be constant"
-----------------------------------------------------------
-    , "not expr"     ~: ""
-                     ~: cExprStr "not c"
-                     ?: cExprStr "c"
-                     >: Right [Instruction opNot 0 0 ""]
+    , "in expr"     ~: "right-hand side of IN is not a constant (not-expr)"
+                    ~: cExprStr "x in (not x)"
+                    ?: Left "Right-hand side of IN operator must be constant"
+---------------------------------------------------------
+    , "not expr"    ~: ""
+                    ~: cExprStr "not c"
+                    ?: cExprStr "c"
+                    >: Right [Instruction opNot 0 0 ""]
 ----------------------------------------------------------
 -- Test code generator: cExprWrapper
 ----------------------------------------------------------
-    , "test index"   ~: "" -- use index idx_yyy_d and idx_xxx_a_b, eq-pair xxx.a = 3 fall back to simple expr
-                           -- index: (xxx.a, xxx.b) = (3, 4)
-                           -- index: yyy.d = 1 + 2
-                           -- cond : yyy.a = 1 and yyy.b > 10
-                     ~: cExprWrapperStr "d = 1 + 2 and 4 = xxx.b  and xxx.a = 3 and yyy.a = 1 and yyy.b > 10"
-                     ?: Right [Instruction opOpen     0 0 "xxx"
-                              ,Instruction opOpen     1 0 "yyy"
-                              ,Instruction opOpen     2 0 "idx_xxx_a_b"
-                              ,Instruction opOpen     3 0 "idx_yyy_d"
-                              ,Instruction opInteger  3 0 ""
-                              ,Instruction opInteger  4 0 ""
-                              ,Instruction opMakeKey  2 0 ""
-                              ,Instruction opBeginIdx 2 0 ""
-                              ,Instruction opNoop     0 1 ""
-                              ,Instruction opNextIdx  2 0 ""
-                              ,Instruction opMoveTo   0 0 ""]
-                     /: cExprStr "1+2"
-                     >: Right [Instruction opMakeKey  1 0 ""
-                              ,Instruction opBeginIdx 3 0 ""
-                              ,Instruction opNoop     0 2 ""
-                              ,Instruction opNextIdx  3 1 ""
-                              ,Instruction opMoveTo   1 0 ""]
-                     /: (putLabel 3 >> cExprStr "yyy.a = 1 and yyy.b>10")
-                     >: Right [Instruction opNot      0 0 ""
-                              ,Instruction opJIf      0 2 ""
-                              ,Instruction opTempInst 0 0 ""
-                              ,Instruction opGoto     0 2 ""
-                              ,Instruction opNoop     0 0 ""
-                              ,Instruction opClose    0 0 ""
-                              ,Instruction opClose    1 0 ""
-                              ,Instruction opClose    2 0 ""
-                              ,Instruction opClose    3 0 ""]
-    , "test index"   ~: "" -- only use index idx_yyy_d
-                           -- index: yyy.d = 1
-                           -- cond : xxx.b > 10 and yyy.a > 9
-                     ~: cExprWrapperStr "xxx.b > 10 and d = 1 and yyy.a > 9"
-                     ?: Right [Instruction opOpen     0 0 "xxx"
-                              ,Instruction opOpen     1 0 "yyy"
-                              ,Instruction opOpen     2 0 "idx_yyy_d"
-                              ,Instruction opInteger  1 0 ""
-                              ,Instruction opMakeKey  1 0 ""
-                              ,Instruction opBeginIdx 2 0 ""
-                              ,Instruction opNoop     0 1 ""
-                              ,Instruction opNextIdx  2 0 ""
-                              ,Instruction opMoveTo   1 0 ""
-                              ,Instruction opRewind   0 0 ""
-                              ,Instruction opNoop     0 2 ""
-                              ,Instruction opNext     0 1 ""]
-                     /: (putLabel 3 >> cExprStr "yyy.a > 9 and xxx.b > 10")
-                     >: Right [Instruction opNot      0 0 ""
-                              ,Instruction opJIf      0 2 ""
-                              ,Instruction opTempInst 0 0 ""
-                              ,Instruction opGoto     0 2 ""
-                              ,Instruction opNoop     0 0 ""
-                              ,Instruction opClose    0 0 ""
-                              ,Instruction opClose    1 0 ""
-                              ,Instruction opClose    2 0 ""]
+-- NOTE the expr collected first is at the end of the list, so expr should be reversed
+-- XXX  expr order can be optimized
+{-
+
+    rewind "xxx"                                      rewind "xxx"
+    next   "xxx"                                      next   "xxx"
+    rewind "yyy"                        -->           expr "xxx.b > 10"
+    next   "yyy"                                      rewind "yyy"
+    expr "yyy.a > 9 and xxx.b > 10"                   next   "yyy"
+                                                      expr "yyy.a > 9"
+-}
+
+    , "test index"  ~: "" -- use index idx_yyy_d and idx_xxx_a_b, eq-pair xxx.a = 3 fall back to simple expr
+                          -- index: (xxx.a, xxx.b) = (3, 4)
+                          -- index: yyy.d = 1 + 2
+                          -- cond : yyy.a = 1 and yyy.b > 10
+                    ~: cExprWrapperStr "d = 1 + 2 and 4 = xxx.b  and xxx.a = 3 and yyy.a = 1 and yyy.b > 10"
+                    ?: Right [Instruction opOpen     0 0 "xxx"
+                             ,Instruction opOpen     1 0 "yyy"
+                             ,Instruction opOpen     2 0 "idx_xxx_a_b"
+                             ,Instruction opOpen     3 0 "idx_yyy_d"
+                             ,Instruction opInteger  3 0 ""
+                             ,Instruction opInteger  4 0 ""
+                             ,Instruction opMakeKey  2 0 ""
+                             ,Instruction opBeginIdx 2 0 ""
+                             ,Instruction opNoop     0 1 ""
+                             ,Instruction opNextIdx  2 0 ""
+                             ,Instruction opMoveTo   0 0 ""]
+                    /: cExprStr "1+2"
+                    >: Right [Instruction opMakeKey  1 0 ""
+                             ,Instruction opBeginIdx 3 0 ""
+                             ,Instruction opNoop     0 2 ""
+                             ,Instruction opNextIdx  3 1 ""
+                             ,Instruction opMoveTo   1 0 ""]
+                    /: (putLabel 3 >> cExprStr "yyy.a = 1 and yyy.b>10")
+                    >: Right [Instruction opNot      0 0 ""
+                             ,Instruction opJIf      0 2 ""
+                             ,Instruction opTempInst 0 0 ""
+                             ,Instruction opGoto     0 2 ""
+                             ,Instruction opNoop     0 0 ""
+                             ,Instruction opClose    0 0 ""
+                             ,Instruction opClose    1 0 ""
+                             ,Instruction opClose    2 0 ""
+                             ,Instruction opClose    3 0 ""]
+    , "test index"  ~: "" -- only use index idx_yyy_d
+                          -- index: yyy.d = 1
+                          -- cond : xxx.b > 10 and yyy.a > 9
+                    ~: cExprWrapperStr "xxx.b > 10 and d = 1 and yyy.a > 9"
+                    ?: Right [Instruction opOpen     0 0 "xxx"
+                             ,Instruction opOpen     1 0 "yyy"
+                             ,Instruction opOpen     2 0 "idx_yyy_d"
+                             ,Instruction opInteger  1 0 ""
+                             ,Instruction opMakeKey  1 0 ""
+                             ,Instruction opBeginIdx 2 0 ""
+                             ,Instruction opNoop     0 1 ""
+                             ,Instruction opNextIdx  2 0 ""
+                             ,Instruction opMoveTo   1 0 ""
+                             ,Instruction opRewind   0 0 ""
+                             ,Instruction opNoop     0 2 ""
+                             ,Instruction opNext     0 1 ""]
+                    /: (putLabel 3 >> cExprStr "yyy.a > 9 and xxx.b > 10")
+                    >: Right [Instruction opNot      0 0 ""
+                             ,Instruction opJIf      0 2 ""
+                             ,Instruction opTempInst 0 0 ""
+                             ,Instruction opGoto     0 2 ""
+                             ,Instruction opNoop     0 0 ""
+                             ,Instruction opClose    0 0 ""
+                             ,Instruction opClose    1 0 ""
+                             ,Instruction opClose    2 0 ""]
+    , "test index"  ~: "no index"
+                    ~: cExprWrapperStr "xxx.b > 10 and yyy.a > 9"
+                    ?: Right [Instruction opOpen     0 0 "xxx"
+                             ,Instruction opOpen     1 0 "yyy"
+                             ,Instruction opRewind   0 0 ""
+                             ,Instruction opNoop     0 1 ""
+                             ,Instruction opNext     0 0 ""
+                             ,Instruction opRewind   1 0 ""
+                             ,Instruction opNoop     0 2 ""
+                             ,Instruction opNext     1 1 ""]
+                    /: (putLabel 3 >> cExprStr "yyy.a > 9 and xxx.b > 10")
+                    >: Right [Instruction opNot      0 0 ""
+                             ,Instruction opJIf      0 2 ""
+                             ,Instruction opTempInst 0 0 ""
+                             ,Instruction opGoto     0 2 ""
+                             ,Instruction opNoop     0 0 ""
+                             ,Instruction opClose    0 0 ""
+                             ,Instruction opClose    1 0 ""]
+
     ]

--- a/src/frontend/compiler/src/Test/TestCodeGenerator.hs
+++ b/src/frontend/compiler/src/Test/TestCodeGenerator.hs
@@ -194,6 +194,13 @@ codeGeneratorTest =
                      ~: cExpr (FunctionCall "min" [Column "c", Column "d"])
                      ?: cExpr (Column "c") +: cExpr (Column "d")
                      >: Right [Instruction opMin 0 0 ""]
+
+    , "func call"    ~: ""
+                     ~: cExpr (FunctionCall "substr" [Column "c", ConstValue $ ValInt 1, ConstValue $ ValInt 2])
+                     ?: cExpr (Column "c")
+                     >: Right [Instruction opInteger 1 0 ""
+                              ,Instruction opInteger 2 0 ""
+                              ,Instruction opSubstr  0 0 ""]
 ----------------------------------------------------------
     , "is null"      ~: ""
                      ~: cExpr (IsNull $ Column "c")

--- a/src/frontend/compiler/src/Test/TestUtils.hs
+++ b/src/frontend/compiler/src/Test/TestUtils.hs
@@ -1,8 +1,11 @@
 module TestUtils where
 
+
+import Expr
 import Parser
 import Instruction
 import FFIStructure
+import CodeGenerator
 import CodeGeneratorUtils
 
 import Test.HUnit
@@ -23,6 +26,12 @@ testEnv = (
 
 runCodeGen :: CodeGenEnv -> CodeGenRes
 runCodeGen x = evalState (runExceptT x) testEnv
+
+cExprStr :: String -> CodeGenEnv
+cExprStr s = cExpr $ runParser expr s
+
+cExprWrapperStr :: String -> CodeGenEnv
+cExprWrapperStr s = cExprWrapper $ runParser expr s
 
 runParser :: Parser a -> String -> a
 runParser p s = case parse p s of

--- a/src/frontend/compiler/src/Test/TestUtils.hs
+++ b/src/frontend/compiler/src/Test/TestUtils.hs
@@ -21,7 +21,7 @@ testEnv = (
      ,TableMetadata "yyy" [("idx_yyy_d", ["d"]), ("idx_yyy_a_b", ["a", "b"])] ["a", "b", "d", "y"] 0]
     ,[("max", 2, Just opMax), ("min", 2, Just opMin), ("substr", 3, Just opSubstr)])
     , []
-    , (0, 0, 0))
+    , (0, 0))
 
 
 runCodeGen :: CodeGenEnv -> CodeGenRes

--- a/src/frontend/compiler/src/Test/TestUtils.hs
+++ b/src/frontend/compiler/src/Test/TestUtils.hs
@@ -1,5 +1,6 @@
 module TestUtils where
 
+import Parser
 import Instruction
 import FFIStructure
 import CodeGeneratorUtils
@@ -13,7 +14,8 @@ type CGTestCase = (CodeGenEnv, CodeGenRes)
 
 testEnv :: CodeGenState
 testEnv = (
-    ([TableMetadata "xxx" [] ["a", "b", "c", "x"] 0, TableMetadata "yyy" [] ["a", "b", "d", "y"] 0]
+    ([TableMetadata "xxx" [("idx_xxx_a", ["a"]), ("idx_xxx_a_b", ["a", "b"])] ["a", "b", "c", "x"] 0
+     ,TableMetadata "yyy" [("idx_yyy_d", ["d"]), ("idx_yyy_a_b", ["a", "b"])] ["a", "b", "d", "y"] 0]
     ,[("max", 2, Just opMax), ("min", 2, Just opMin), ("substr", 3, Just opSubstr)])
     , []
     , (0, 0, 0))
@@ -21,6 +23,11 @@ testEnv = (
 
 runCodeGen :: CodeGenEnv -> CodeGenRes
 runCodeGen x = evalState (runExceptT x) testEnv
+
+runParser :: Parser a -> String -> a
+runParser p s = case parse p s of
+    Just (a, _) -> a
+    _           -> error $ "parse error: " ++ s
 
 
 infixl 3 +:

--- a/src/frontend/compiler/src/Test/TestUtils.hs
+++ b/src/frontend/compiler/src/Test/TestUtils.hs
@@ -1,10 +1,10 @@
 module TestUtils where
 
-
-import Test.HUnit
+import Instruction
 import FFIStructure
 import CodeGeneratorUtils
 
+import Test.HUnit
 import Control.Monad.State
 import Control.Monad.Except
 
@@ -13,10 +13,10 @@ type CGTestCase = (CodeGenEnv, CodeGenRes)
 
 testEnv :: CodeGenState
 testEnv = (
-    [ TableMetadata "xxx" [] ["a", "b", "c", "x"] 0
-    , TableMetadata "yyy" [] ["a", "b", "d", "y"] 0]
+    ([TableMetadata "xxx" [] ["a", "b", "c", "x"] 0, TableMetadata "yyy" [] ["a", "b", "d", "y"] 0]
+    ,[("max", 2, Just opMax), ("min", 2, Just opMin), ("substr", 3, Just opSubstr)])
     , []
-    , (0, 0))
+    , (0, 0, 0))
 
 
 runCodeGen :: CodeGenEnv -> CodeGenRes


### PR DESCRIPTION
- 带索引的表达式只会在 select, update 和 delete 的 cond 中使用
- 由于左结合运算的左子树通常会比较大，因此 And 和 Or 表达式改成先检查右子树